### PR TITLE
Fix CI environment for Scala tests

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -42,4 +42,5 @@ jobs:
         run: sbt test
         # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository
       - name: Upload dependency graph
+        if: github.repository == 'tobia80/DRef' && github.event_name != 'pull_request'
         uses: scalacenter/sbt-dependency-submission@ab086b50c947c9774b70f39fc7f6e20ca2706c91

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -16,21 +16,30 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 11
-      uses: actions/setup-java@v4
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'sbt'
-    - name: Setup sbt
-      uses: sbt/setup-sbt@v1    
-    - name: Run tests
-      run: sbt test
-      # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository
-    - name: Upload dependency graph
-      uses: scalacenter/sbt-dependency-submission@ab086b50c947c9774b70f39fc7f6e20ca2706c91
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'sbt'
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+      - name: Run tests
+        run: sbt test
+        # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository
+      - name: Upload dependency graph
+        uses: scalacenter/sbt-dependency-submission@ab086b50c947c9774b70f39fc7f6e20ca2706c91


### PR DESCRIPTION
## Summary
- update the Scala CI workflow to run on Java 21 and provide a Redis service
- keep dependency graph submission while ensuring steps are properly indented

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_b_68ef993aadec83298db92c404d3a6bb1