### PR TITLE
Ensure DRef lock release verifies ownership

### DIFF
--- a/dref-raft/src/main/protobuf/dref.proto
+++ b/dref-raft/src/main/protobuf/dref.proto
@@ -49,9 +49,6 @@ message DeleteElementRequest {
 }
 message DeleteElementResponse {}
 
-
-
-
 message SendCommandRequest {
   string id = 1;
   bytes payload = 2;


### PR DESCRIPTION
## Summary
- verify lock release by checking the stored token before deleting it
- remove the deleteElementIfValueMatches abstraction and related Redis/Raft plumbing
- keep the regression test ensuring a reacquired lock is preserved

## Testing
- not run (sbt command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68f3682c2f688329a6b4e13a189155dd