### PR TITLE
Add Kubernetes IpProvider using zio-k8s Endpoints API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import Dependencies.zio
+import Dependencies.{zio, zioK8s, sttp}
 
 import scala.collection.Seq
 
@@ -48,7 +48,11 @@ val raftDeps = Seq(
 
   // grpc
   "io.grpc"               % "grpc-netty"           % "1.76.0",
-  "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
+  "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,
+
+  // kubernetes service discovery
+  "com.coralogix"                    %% "zio-k8s-client" % zioK8s,
+  "com.softwaremill.sttp.client3"    %% "slf4j-backend"  % sttp
 ) ++ testDeps
 
 lazy val commonProtobufSettings = Seq(

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/IpProvider.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/IpProvider.scala
@@ -1,6 +1,6 @@
 package io.github.tobia80.dref.raft
 
-import zio.{Task, ZEnvironment, ZIO, ZLayer}
+import zio.{Task, ZIO, ZLayer}
 
 trait IpProvider {
   def findNodeAddresses(): Task[List[String]]
@@ -14,17 +14,9 @@ object IpProvider {
 
   def k8s(
       serviceName: String,
-      myAddress: String,
       namespace: String
   ): ZLayer[Any, Throwable, IpProvider] =
-    KubernetesIpProvider.live(serviceName, namespace).map { env =>
-      val delegate = env.get[IpProvider]
-      ZEnvironment(new IpProvider {
-        override def findNodeAddresses(): Task[List[String]] = delegate.findNodeAddresses()
-        override def findMyAddress(): Task[String]           = ZIO.succeed(myAddress)
-        override def expectedEndpoints: Task[Int]            = delegate.expectedEndpoints
-      })
-    }
+    KubernetesIpProvider.live(serviceName, namespace)
 
   def local: ZLayer[Any, Nothing, IpProvider] = ZLayer.succeed {
     new IpProvider {

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/KubernetesIpProvider.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/KubernetesIpProvider.scala
@@ -1,0 +1,54 @@
+package io.github.tobia80.dref.raft
+
+import com.coralogix.zio.k8s.client.config.*
+import com.coralogix.zio.k8s.client.config.httpclient.*
+import com.coralogix.zio.k8s.client.v1.endpoints.Endpointses
+import com.coralogix.zio.k8s.client.model.K8sNamespace
+import com.coralogix.zio.k8s.client.K8sFailure
+import zio.*
+
+object KubernetesIpProvider {
+
+  private def k8sFailureToThrowable(failure: K8sFailure): Throwable =
+    RuntimeException(s"Kubernetes API error: $failure")
+
+  def live(
+      serviceName: String,
+      namespace: String
+  ): ZLayer[Any, Throwable, IpProvider] =
+    ZLayer.scoped {
+      for {
+        endpointsSvc <- ZIO
+                          .service[Endpointses]
+                          .provideLayer(k8sDefault >>> Endpointses.live)
+      } yield create(serviceName, namespace, endpointsSvc)
+    }
+
+  private[raft] def create(
+      serviceName: String,
+      namespace: String,
+      endpointsSvc: Endpointses
+  ): IpProvider = {
+    val k8sNamespace = K8sNamespace(namespace)
+    new IpProvider {
+
+      override def findNodeAddresses(): Task[List[String]] =
+        endpointsSvc
+          .get(serviceName, k8sNamespace)
+          .mapError(k8sFailureToThrowable)
+          .map { ep =>
+            val subsets = ep.subsets.toOption.getOrElse(Vector.empty)
+            subsets.flatMap { subset =>
+              subset.addresses.toOption.getOrElse(Vector.empty).map(_.ip)
+            }.toList
+          }
+
+      override def findMyAddress(): Task[String] = ZIO.attempt {
+        java.net.InetAddress.getLocalHost.getHostAddress
+      }
+
+      override def expectedEndpoints: Task[Int] =
+        findNodeAddresses().map(_.size)
+    }
+  }
+}

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/KubernetesIpProvider.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/KubernetesIpProvider.scala
@@ -26,13 +26,7 @@ object KubernetesIpProvider {
       serviceName: String,
       namespace: String
   ): ZLayer[Any, Throwable, IpProvider] =
-    ZLayer.scoped {
-      for {
-        endpointsSvc <- ZIO
-                          .service[Endpointses]
-                          .provideLayer(k8sDefault >>> Endpointses.live)
-      } yield create(serviceName, namespace, endpointsSvc)
-    }
+    (k8sDefault >>> Endpointses.live) >>> ZLayer.fromFunction(create(serviceName, namespace, _))
 
   private[raft] def create(
       serviceName: String,

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/KubernetesIpProviderSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/KubernetesIpProviderSpec.scala
@@ -37,9 +37,11 @@ object KubernetesIpProviderSpec extends ZIOSpecDefault {
     },
     test("findMyAddress should return local host address") {
       for {
-        svc     <- ZIO.service[Endpointses]
-        provider = KubernetesIpProvider.create(serviceName, namespace, svc)
-        myAddr  <- provider.findMyAddress()
+        svc      <- ZIO.service[Endpointses]
+        _        <- svc.create(makeEndpoints(serviceName, List("10.0.0.1", "10.0.0.2")), K8sNamespace(namespace))
+                       .mapError(e => RuntimeException(s"Failed to create test endpoints: $e"))
+        provider  = KubernetesIpProvider.create(serviceName, namespace, svc)
+        myAddr   <- provider.findMyAddress()
       } yield assertTrue(myAddr.nonEmpty)
     },
     test("expectedEndpoints should return the count of IPs") {

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/KubernetesIpProviderSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/KubernetesIpProviderSpec.scala
@@ -1,0 +1,89 @@
+package io.github.tobia80.dref.raft
+
+import com.coralogix.zio.k8s.client.model.K8sNamespace
+import com.coralogix.zio.k8s.client.v1.endpoints.Endpointses
+import com.coralogix.zio.k8s.model.core.v1.{EndpointAddress, EndpointSubset, Endpoints as K8sEndpoints}
+import com.coralogix.zio.k8s.model.pkg.apis.meta.v1.ObjectMeta
+import zio.*
+import zio.prelude.data.Optional
+import zio.test.{assertTrue, Spec, TestEnvironment, ZIOSpecDefault}
+
+object KubernetesIpProviderSpec extends ZIOSpecDefault {
+
+  private val serviceName = "my-service"
+  private val namespace   = "default"
+
+  private def makeEndpoints(name: String, ips: List[String]): K8sEndpoints =
+    K8sEndpoints(
+      metadata = Optional.Present(ObjectMeta(name = Optional.Present(name))),
+      subsets = Optional.Present(
+        Vector(
+          EndpointSubset(
+            addresses = Optional.Present(ips.map(ip => EndpointAddress(ip = ip)).toVector)
+          )
+        )
+      )
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] = suite("KubernetesIpProvider")(
+    test("findNodeAddresses should return IPs from Endpoints resource") {
+      for {
+        svc      <- ZIO.service[Endpointses]
+        _        <- svc.create(makeEndpoints(serviceName, List("10.0.0.1", "10.0.0.2", "10.0.0.3")), K8sNamespace(namespace))
+                       .mapError(e => RuntimeException(s"Failed to create test endpoints: $e"))
+        provider  = KubernetesIpProvider.create(serviceName, namespace, svc)
+        ips      <- provider.findNodeAddresses()
+      } yield assertTrue(ips == List("10.0.0.1", "10.0.0.2", "10.0.0.3"))
+    },
+    test("findMyAddress should return local host address") {
+      for {
+        svc     <- ZIO.service[Endpointses]
+        provider = KubernetesIpProvider.create(serviceName, namespace, svc)
+        myAddr  <- provider.findMyAddress()
+      } yield assertTrue(myAddr.nonEmpty)
+    },
+    test("expectedEndpoints should return the count of IPs") {
+      for {
+        svc      <- ZIO.service[Endpointses]
+        _        <- svc.create(makeEndpoints(serviceName, List("10.0.0.1", "10.0.0.2")), K8sNamespace(namespace))
+                       .mapError(e => RuntimeException(s"Failed to create test endpoints: $e"))
+        provider  = KubernetesIpProvider.create(serviceName, namespace, svc)
+        count    <- provider.expectedEndpoints
+      } yield assertTrue(count == 2)
+    },
+    test("findNodeAddresses should handle multiple subsets") {
+      val endpoints = K8sEndpoints(
+        metadata = Optional.Present(ObjectMeta(name = Optional.Present("multi-subset-svc"))),
+        subsets = Optional.Present(
+          Vector(
+            EndpointSubset(
+              addresses = Optional.Present(Vector(EndpointAddress(ip = "10.0.1.1"), EndpointAddress(ip = "10.0.1.2")))
+            ),
+            EndpointSubset(
+              addresses = Optional.Present(Vector(EndpointAddress(ip = "10.0.2.1")))
+            )
+          )
+        )
+      )
+      for {
+        svc      <- ZIO.service[Endpointses]
+        _        <- svc.create(endpoints, K8sNamespace(namespace))
+                       .mapError(e => RuntimeException(s"Failed to create test endpoints: $e"))
+        provider  = KubernetesIpProvider.create("multi-subset-svc", namespace, svc)
+        ips      <- provider.findNodeAddresses()
+      } yield assertTrue(ips == List("10.0.1.1", "10.0.1.2", "10.0.2.1"))
+    },
+    test("findNodeAddresses should return empty list when no subsets") {
+      val endpoints = K8sEndpoints(
+        metadata = Optional.Present(ObjectMeta(name = Optional.Present("empty-svc")))
+      )
+      for {
+        svc      <- ZIO.service[Endpointses]
+        _        <- svc.create(endpoints, K8sNamespace(namespace))
+                       .mapError(e => RuntimeException(s"Failed to create test endpoints: $e"))
+        provider  = KubernetesIpProvider.create("empty-svc", namespace, svc)
+        ips      <- provider.findNodeAddresses()
+      } yield assertTrue(ips.isEmpty)
+    }
+  ).provide(Endpointses.test)
+}

--- a/example/src/main/scala/io/tobia80/dref/Main.scala
+++ b/example/src/main/scala/io/tobia80/dref/Main.scala
@@ -20,7 +20,6 @@ object Main extends ZIOAppDefault {
   private val PortEnvironment = "DREF_PORT"
   private val K8sService   = "DREF_K8S_SERVICE"
   private val K8sNamespace = "DREF_K8S_NAMESPACE"
-  private val K8sMyAddress = "DREF_K8S_MY_ADDRESS"
 
   private val raftConfigLayer: ZLayer[Any, Nothing, RaftConfig] = {
     val port = sys.env
@@ -40,9 +39,8 @@ object Main extends ZIOAppDefault {
 
     (for {
       service   <- sys.env.get(K8sService)
-      myAddress <- sys.env.get(K8sMyAddress)
       namespace <- sys.env.get(K8sNamespace)
-    } yield IpProvider.k8s(service, myAddress, namespace))
+    } yield IpProvider.k8s(service, namespace))
       .orElse(parse(NodesAddresses).map(addresses => IpProvider.static(addresses*)))
       .orElse(parse(NodesServices).map(services => IpProvider.dnsBased(services*)))
       .getOrElse(IpProvider.local)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,7 @@
 object Dependencies {
 
-  val zio = "2.1.21"
+  val zio    = "2.1.21"
+  val zioK8s = "3.1.3"
+  val sttp   = "3.11.0"
 
 }


### PR DESCRIPTION
Adds native Kubernetes service discovery via the zio-k8s library, querying the Endpoints API to resolve pod IPs for a given service name.