### PR TITLE
Fix critical bugs in raft lock implementation

### DIFF
--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/DRefGrpcServer.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/DRefGrpcServer.scala
@@ -158,3 +158,5 @@ class DRefGrpcServer(
 case class LeaderException(leaderId: String, leaderAddress: String, status: Status) extends StatusException(status) {}
 
 case class NodeDescriptor(id: String, node: RaftNode, transport: GrpcTransport)
+
+case class DeleteIfExpiredRequest(name: String, expiredBefore: Long)

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/DRefStateMachineSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/DRefStateMachineSpec.scala
@@ -1,0 +1,81 @@
+package io.github.tobia80.dref.raft
+
+import com.google.protobuf.ByteString
+import io.github.tobia80.dref.*
+import reactor.core.publisher.Sinks
+import zio.*
+import zio.test.{assertTrue, Spec, TestEnvironment, ZIOSpecDefault}
+
+object DRefStateMachineSpec extends ZIOSpecDefault {
+
+  private def makeStateMachine(): DRefStateMachine = {
+    val sink = Sinks.many().multicast().onBackpressureBuffer[ChangeEvent]()
+    new DRefStateMachine(sink)
+  }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] = suite("DRefStateMachine")(
+    suite("deleteIfExpired")(
+      test("should delete an expired element") {
+        val sm = makeStateMachine()
+        val value = ByteString.copyFrom("hello".getBytes)
+        sm.runOperation(1, SetElementRequest(name = "key", value = value, expireAt = Some(1000L)))
+        val result = sm.runOperation(2, DeleteIfExpiredRequest("key", expiredBefore = 2000L))
+        val getResult = sm.runOperation(3, GetElementRequest(name = "key"))
+        assertTrue(result != null, getResult == null)
+      },
+      test("should delete element when expireAt equals expiredBefore") {
+        val sm = makeStateMachine()
+        val value = ByteString.copyFrom("hello".getBytes)
+        sm.runOperation(1, SetElementRequest(name = "key", value = value, expireAt = Some(1000L)))
+        val result = sm.runOperation(2, DeleteIfExpiredRequest("key", expiredBefore = 1000L))
+        val getResult = sm.runOperation(3, GetElementRequest(name = "key"))
+        assertTrue(result != null, getResult == null)
+      },
+      test("should not delete a non-expired element") {
+        val sm = makeStateMachine()
+        val value = ByteString.copyFrom("hello".getBytes)
+        sm.runOperation(1, SetElementRequest(name = "key", value = value, expireAt = Some(2000L)))
+        val result = sm.runOperation(2, DeleteIfExpiredRequest("key", expiredBefore = 1000L))
+        val getResult = sm.runOperation(3, GetElementRequest(name = "key"))
+        assertTrue(result == null, getResult != null)
+      },
+      test("should return null for non-existent element") {
+        val sm = makeStateMachine()
+        val result = sm.runOperation(1, DeleteIfExpiredRequest("non-existent", expiredBefore = 2000L))
+        assertTrue(result == null)
+      },
+      test("should not delete element without expiration") {
+        val sm = makeStateMachine()
+        val value = ByteString.copyFrom("hello".getBytes)
+        sm.runOperation(1, SetElementRequest(name = "key", value = value, expireAt = None))
+        val result = sm.runOperation(2, DeleteIfExpiredRequest("key", expiredBefore = 2000L))
+        val getResult = sm.runOperation(3, GetElementRequest(name = "key"))
+        assertTrue(result == null, getResult != null)
+      }
+    ),
+    suite("retrieveExpirationTable")(
+      test("should only return elements with expiration") {
+        val sm = makeStateMachine()
+        sm.runOperation(
+          1,
+          SetElementRequest(name = "with-expiry", value = ByteString.copyFrom("a".getBytes), expireAt = Some(1000L))
+        )
+        sm.runOperation(
+          2,
+          SetElementRequest(name = "without-expiry", value = ByteString.copyFrom("b".getBytes), expireAt = None)
+        )
+        val result = sm.runOperation(3, GetExpirationTableRequest()).asInstanceOf[Map[String, Long]]
+        assertTrue(result == Map("with-expiry" -> 1000L))
+      },
+      test("should return empty map when no elements have expiration") {
+        val sm = makeStateMachine()
+        sm.runOperation(
+          1,
+          SetElementRequest(name = "no-expiry", value = ByteString.copyFrom("a".getBytes), expireAt = None)
+        )
+        val result = sm.runOperation(2, GetExpirationTableRequest()).asInstanceOf[Map[String, Long]]
+        assertTrue(result.isEmpty)
+      }
+    )
+  )
+}


### PR DESCRIPTION
- Fix retrieveExpirationTable: use .collect instead of .map to avoid
  MatchError when entries without expiration (expireAt=None) exist
- Fix expireElements: replace DeleteElementRequest(name) which mapped
  the element name to the wrong proto field (id instead of name),
  causing TTL-based expiration to never actually delete anything
- Add DeleteIfExpiredRequest for atomic conditional deletion that
  checks the element's current expiration before deleting, preventing
  a race where a renewed/reacquired lock could be accidentally deleted
- Implement detectStolenElement with polling (was ZStream.never) so
  lock holders are notified when their lock value changes or disappears
- Implement detectDeletionFromUnderlyingStream with polling (was
  ZStream.never) as a fallback for lock waiters if hub events are missed

https://claude.ai/code/session_01Mymz9Z316QFy4wSn1R98ZK