### PR TITLE
Redis resiliency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,14 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# IDE / Metals
+.metals
+.vscode
+.bloop
+
+# sbt
+target/
+project/target/
+project/project/
+project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,8 @@ val coreDeps = Seq(
 ) ++ testDeps
 
 val redisDeps = Seq(
-  "io.lettuce" % "lettuce-core" % "6.8.1.RELEASE"
+  "io.lettuce"         % "lettuce-core"  % "6.8.1.RELEASE",
+  "org.apache.commons" % "commons-pool2" % "2.12.0"
 ) ++ testDeps
 
 val raftDeps = Seq(

--- a/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisClient.scala
+++ b/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisClient.scala
@@ -1,16 +1,17 @@
 package io.github.tobia80.dref.redis
 
 import io.lettuce.core
-import io.lettuce.core.SetArgs
+import io.lettuce.core.{RedisCommandExecutionException, RedisCommandTimeoutException, RedisException, SetArgs}
+import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.codec.ByteArrayCodec
 import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands
+import io.lettuce.core.support.{AsyncConnectionPoolSupport, BoundedPoolConfig}
+import io.lettuce.core.support.AsyncPool
 import reactor.core.publisher.Mono
 import zio.stream.ZStream
 import zio.{Chunk, Scope, Task, ZIO}
 import zio.*
-
-import scala.concurrent.duration.FiniteDuration
 
 trait RedisClient {
 
@@ -32,51 +33,107 @@ trait RedisClient {
 
 object RedisClient {
 
-  def make(config: RedisConfig): ZIO[Scope, Throwable, RedisClient] =
+  private[redis] def isTransient(e: Throwable): Boolean = e match {
+    case _: RedisCommandTimeoutException                                    => true
+    case _: RedisCommandExecutionException                                  => false
+    case _: RedisException                                                  => true
+    case _: java.io.IOException                                             => true
+    case c: java.util.concurrent.CompletionException if c.getCause != null  => isTransient(c.getCause)
+    case _                                                                  => false
+  }
+
+  private[redis] def retrySchedule(config: RetryConfig): Schedule[Any, Throwable, Any] =
+    (Schedule.recurWhile[Throwable](isTransient) &&
+      (Schedule.exponential(config.initialDelay, 2.0) || Schedule.fixed(config.maxDelay)) &&
+      Schedule.recurs(config.maxRetries)).unit
+
+  def make(config: RedisConfig): ZIO[Scope, Throwable, RedisClient] = {
+    val schedule = retrySchedule(config.retry)
+
     ZIO.acquireRelease {
-      ZIO.attempt {
-        val client: core.RedisClient = core.RedisClient.create(config.toRedisURI)
-        client.setOptions(config.toOptions)
-        val asyncClient = client.connect(ByteArrayCodec.INSTANCE).async
-        val reactive = client.connectPubSub(ByteArrayCodec.INSTANCE).reactive()
-        LettuceRedisClient(client, asyncClient, reactive)
-      }
-    }(client => client.close().ignore)
+      {
+        for {
+          client <- ZIO.attempt {
+                      val c = core.RedisClient.create(config.toRedisURI)
+                      c.setOptions(config.toOptions)
+                      c
+                    }
+          poolCfg = BoundedPoolConfig.builder()
+                      .minIdle(config.pool.minIdle)
+                      .maxIdle(config.pool.maxIdle)
+                      .maxTotal(config.pool.maxTotal)
+                      .build()
+          result <- {
+            for {
+              pool   <- ZIO.fromCompletionStage(
+                          AsyncConnectionPoolSupport.createBoundedObjectPoolAsync(
+                            () => client.connectAsync(ByteArrayCodec.INSTANCE, config.toRedisURI),
+                            poolCfg
+                          )
+                        )
+              pubsub <- ZIO.attempt(client.connectPubSub(ByteArrayCodec.INSTANCE).reactive())
+                          .tapError(_ => ZIO.fromCompletionStage(pool.closeAsync()).ignore)
+            } yield PooledLettuceRedisClient(client, pool, pubsub, schedule)
+          }.tapError(_ => ZIO.attempt(client.close()).ignore)
+        } yield result
+      }.retry(schedule)
+    }(_.close().ignore)
+  }
 }
 
-class LettuceRedisClient(
+private class PooledLettuceRedisClient(
   client: core.RedisClient,
-  async: RedisAsyncCommands[Array[Byte], Array[Byte]],
-  pubsub: RedisPubSubReactiveCommands[Array[Byte], Array[Byte]]
+  pool: AsyncPool[StatefulRedisConnection[Array[Byte], Array[Byte]]],
+  pubsub: RedisPubSubReactiveCommands[Array[Byte], Array[Byte]],
+  schedule: Schedule[Any, Throwable, Any]
 ) extends RedisClient {
 
   import zio.interop.reactivestreams.*
 
   import scala.language.implicitConversions
 
-  override def set(name: Chunk[Byte], value: Chunk[Byte], ttl: Option[Duration]): Task[String] = ZIO
-    .fromCompletionStage(
-      ttl
-        .fold(async.set(name.toArray, value.toArray))(ttlValue =>
-          async.set(name.toArray, value.toArray, SetArgs.Builder.ex(ttlValue.toSeconds)).toCompletableFuture
-        )
-    )
+  private def withPooledConnection[A](f: RedisAsyncCommands[Array[Byte], Array[Byte]] => Task[A]): Task[A] =
+    ZIO.acquireReleaseWith(
+      ZIO.fromCompletionStage(pool.acquire())
+    )(conn => ZIO.fromCompletionStage(pool.release(conn)).ignore)(conn => f(conn.async()))
 
+  private def withRetry[A](f: RedisAsyncCommands[Array[Byte], Array[Byte]] => Task[A]): Task[A] =
+    withPooledConnection(f).retry(schedule)
+
+  override def set(name: Chunk[Byte], value: Chunk[Byte], ttl: Option[Duration]): Task[String] =
+    withRetry { async =>
+      ZIO.fromCompletionStage(
+        ttl.fold(async.set(name.toArray, value.toArray))(ttlValue =>
+          async.set(name.toArray, value.toArray, SetArgs.Builder.ex(ttlValue.toSeconds))
+        )
+      )
+    }
+
+  // No retry: setNx is used for distributed locking, retrying could cause double-acquisition.
   override def setNx(name: Chunk[Byte], value: Chunk[Byte], ttl: Option[Duration]): Task[Boolean] =
-    ttl match {
-      case Some(duration) =>
-        val setArgs = SetArgs.Builder.nx.ex(duration.getSeconds)
-        ZIO.fromCompletionStage(async.set(name.toArray, value.toArray, setArgs)).map(res => res != null)
-      case None           => ZIO.fromCompletionStage(async.setnx(name.toArray, value.toArray)).map(res => res.booleanValue())
+    withPooledConnection { async =>
+      ttl match {
+        case Some(duration) =>
+          val setArgs = SetArgs.Builder.nx.ex(duration.getSeconds)
+          ZIO.fromCompletionStage(async.set(name.toArray, value.toArray, setArgs)).map(res => res != null)
+        case None           => ZIO.fromCompletionStage(async.setnx(name.toArray, value.toArray)).map(res => res.booleanValue())
+      }
     }
 
   override def get(name: Chunk[Byte]): Task[Option[Chunk[Byte]]] =
-    ZIO.fromCompletionStage(async.get(name.toArray)).map(Option(_).map(Chunk.fromArray))
+    withRetry { async =>
+      ZIO.fromCompletionStage(async.get(name.toArray)).map(Option(_).map(Chunk.fromArray))
+    }
 
-  override def del(name: Chunk[Byte]): Task[Long] = ZIO.fromCompletionStage(async.del(name.toArray)).map(_.longValue())
+  override def del(name: Chunk[Byte]): Task[Long] =
+    withRetry { async =>
+      ZIO.fromCompletionStage(async.del(name.toArray)).map(_.longValue())
+    }
 
   override def expire(name: Chunk[Byte], ttl: Duration): Task[Boolean] =
-    ZIO.fromCompletionStage(async.expire(name.toArray, ttl.toSeconds)).map(_.booleanValue())
+    withRetry { async =>
+      ZIO.fromCompletionStage(async.expire(name.toArray, ttl.toSeconds)).map(_.booleanValue())
+    }
 
   override def publish(channel: Chunk[Byte], message: Chunk[Byte]): Task[Long] =
     monoToZio(pubsub.publish(channel.toArray, message.toArray)).map(_.longValue())
@@ -87,7 +144,9 @@ class LettuceRedisClient(
       .toZIOStream()
       .map(el => Chunk.fromArray(el.getMessage))
 
-  def close(): Task[Unit] = ZIO.attempt(client.close())
+  def close(): Task[Unit] =
+    ZIO.fromCompletionStage(pool.closeAsync()).unit.ignore *>
+      ZIO.attempt(client.close())
 
   private def monoToZio[A](mono: Mono[A]): Task[A] =
     ZIO.async { callback =>

--- a/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisDRefContext.scala
+++ b/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisDRefContext.scala
@@ -8,6 +8,18 @@ import zio.stream.{Take, ZStream}
 
 import java.util
 
+case class RetryConfig(
+  maxRetries: Int = 5,
+  initialDelay: Duration = 200.millis,
+  maxDelay: Duration = 5.seconds
+)
+
+case class PoolConfig(
+  minIdle: Int = 1,
+  maxIdle: Int = 16,
+  maxTotal: Int = 16
+)
+
 case class RedisConfig(
   host: String,
   port: Int,
@@ -15,10 +27,12 @@ case class RedisConfig(
   username: Option[String],
   password: Option[String],
   caCert: Option[String],
-  ttl: Option[Duration]
+  ttl: Option[Duration],
+  retry: RetryConfig = RetryConfig(),
+  pool: PoolConfig = PoolConfig()
 ) {
 
-  def toRedisURI: String = {
+  def toRedisURI: RedisURI = {
     val builder = RedisURI.Builder
       .redis(host, port)
       .withDatabase(database)
@@ -30,10 +44,7 @@ case class RedisConfig(
       case _                  => ()
     }
 
-    builder
-      .build()
-      .toURI
-      .toString
+    builder.build()
   }
 
   def toOptions: ClientOptions = {

--- a/dref-redis/src/test/scala/io/github/tobia80/dref/redis/RedisClientSpec.scala
+++ b/dref-redis/src/test/scala/io/github/tobia80/dref/redis/RedisClientSpec.scala
@@ -1,0 +1,92 @@
+package io.github.tobia80.dref.redis
+
+import io.lettuce.core.{RedisCommandExecutionException, RedisCommandTimeoutException, RedisConnectionException}
+import zio.*
+import zio.test.{assertTrue, Spec, TestAspect, TestEnvironment, ZIOSpecDefault}
+
+import java.io.IOException
+import java.net.SocketException
+import java.util.concurrent.CompletionException
+
+object RedisClientSpec extends ZIOSpecDefault {
+
+  override def spec: Spec[TestEnvironment & Scope, Any] = suite("RedisClient")(
+    isTransientSuite,
+    retryBehaviorSuite
+  )
+
+  private val isTransientSuite = suite("isTransient")(
+    test("RedisCommandTimeoutException is transient") {
+      assertTrue(RedisClient.isTransient(new RedisCommandTimeoutException("timed out")))
+    },
+    test("RedisCommandExecutionException is not transient") {
+      assertTrue(!RedisClient.isTransient(new RedisCommandExecutionException("WRONGTYPE")))
+    },
+    test("RedisConnectionException is transient") {
+      assertTrue(RedisClient.isTransient(new RedisConnectionException("Connection refused")))
+    },
+    test("IOException is transient") {
+      assertTrue(RedisClient.isTransient(new IOException("broken pipe")))
+    },
+    test("SocketException is transient") {
+      assertTrue(RedisClient.isTransient(new SocketException("Connection reset")))
+    },
+    test("CompletionException wrapping transient error is transient") {
+      val wrapped = new CompletionException(new IOException("connection lost"))
+      assertTrue(RedisClient.isTransient(wrapped))
+    },
+    test("CompletionException wrapping non-transient error is not transient") {
+      val wrapped = new CompletionException(new RedisCommandExecutionException("ERR syntax"))
+      assertTrue(!RedisClient.isTransient(wrapped))
+    },
+    test("CompletionException with null cause is not transient") {
+      assertTrue(!RedisClient.isTransient(new CompletionException(null)))
+    },
+    test("arbitrary exception is not transient") {
+      assertTrue(!RedisClient.isTransient(new IllegalArgumentException("bad arg")))
+    }
+  )
+
+  private val retryBehaviorSuite = suite("retry behavior")(
+    test("transient errors are retried") {
+      val config   = RetryConfig(maxRetries = 2, initialDelay = 1.millis, maxDelay = 10.millis)
+      val schedule = RedisClient.retrySchedule(config)
+      for {
+        counter <- Ref.make(0)
+        result  <- counter
+                     .updateAndGet(_ + 1)
+                     .flatMap { n =>
+                       if (n <= 2) ZIO.fail(new RedisConnectionException("Connection refused"))
+                       else ZIO.succeed(n)
+                     }
+                     .retry(schedule)
+      } yield assertTrue(result == 3)
+    },
+    test("non-transient errors fail immediately without retrying") {
+      val config   = RetryConfig(maxRetries = 3, initialDelay = 1.millis, maxDelay = 10.millis)
+      val schedule = RedisClient.retrySchedule(config)
+      for {
+        counter <- Ref.make(0)
+        result  <- counter
+                     .updateAndGet(_ + 1)
+                     .flatMap(_ => ZIO.fail(new RedisCommandExecutionException("WRONGTYPE")))
+                     .retry(schedule)
+                     .either
+        count   <- counter.get
+      } yield assertTrue(result.isLeft && count == 1)
+    },
+    test("retries stop after maxRetries even for transient errors") {
+      val config   = RetryConfig(maxRetries = 2, initialDelay = 1.millis, maxDelay = 10.millis)
+      val schedule = RedisClient.retrySchedule(config)
+      for {
+        counter <- Ref.make(0)
+        result  <- counter
+                     .updateAndGet(_ + 1)
+                     .flatMap(_ => ZIO.fail(new IOException("always fails")))
+                     .retry(schedule)
+                     .either
+        count   <- counter.get
+      } yield assertTrue(result.isLeft && count == 3) // 1 initial + 2 retries
+    }
+  ) @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
Replace single-connection LettuceRedisClient with pooled PooledLettuceRedisClient using Lettuce's AsyncPool
Add configurable exponential-backoff retry with transient error classification
Add RetryConfig and PoolConfig with sensible defaults to RedisConfig