### PR TITLE
Fix 4 bugs and add comprehensive specs

### DIFF
--- a/dref-core/src/test/scala/io/github/tobia80/dref/DRefSpec.scala
+++ b/dref-core/src/test/scala/io/github/tobia80/dref/DRefSpec.scala
@@ -3,7 +3,7 @@ package io.github.tobia80.dref
 import DRef.*
 import DRef.auto.*
 import zio.test.{assertTrue, Spec, TestAspect, TestClock, TestEnvironment, ZIOSpecDefault}
-import zio.{durationInt, Ref, Scope, ZIO}
+import zio.{durationInt, Chunk, Ref, Scope, ZIO}
 
 object DRefSpec extends ZIOSpecDefault {
 
@@ -23,9 +23,9 @@ object DRefSpec extends ZIOSpecDefault {
         _             <- aRef.set("changed again")
         _             <- TestClock.adjust(2.seconds)
         mutations     <- elementsFiber.join
-      } yield assertTrue(mutations == List("hello", "changed again"))
+      } yield assertTrue(mutations == Chunk("hello", "changed again"))
     },
-    test("locks should work") { // two fibers trying to lock the same resource, waiting 1 seconds, queue is written and sleep, when 2 seconds pass, queue is 2 elements
+    test("locks should work") {
       for {
         list              <- Ref.make[List[Int]](Nil)
         fiber             <- ZIO
@@ -43,6 +43,63 @@ object DRefSpec extends ZIOSpecDefault {
         _                 <- fiber.join
         valueWithTwoLocks <- list.get
       } yield assertTrue(valueWithOneLock == List(100) && valueWithTwoLocks == List(100, 200))
+    } @@ TestAspect.withLiveClock,
+    test("modify should atomically read and update") {
+      for {
+        aRef   <- DRef.make(10, ManualId("modify-test"))
+        result <- aRef.modify(v => (v * 2, v + 1))
+        value  <- aRef.get
+      } yield assertTrue(result == 20, value == 11)
+    } @@ TestAspect.withLiveClock,
+    test("update should apply function to current value") {
+      for {
+        aRef  <- DRef.make(5, ManualId("update-test"))
+        _     <- aRef.update(_ + 10)
+        value <- aRef.get
+      } yield assertTrue(value == 15)
+    } @@ TestAspect.withLiveClock,
+    test("getAndUpdate should return old value and apply update") {
+      for {
+        aRef     <- DRef.make(42, ManualId("getAndUpdate-test"))
+        oldValue <- aRef.getAndUpdate(_ + 8)
+        newValue <- aRef.get
+      } yield assertTrue(oldValue == 42, newValue == 50)
+    } @@ TestAspect.withLiveClock,
+    test("updateAndGet should apply update and return new value") {
+      for {
+        aRef     <- DRef.make(10, ManualId("updateAndGet-test"))
+        newValue <- aRef.updateAndGet(_ * 3)
+        current  <- aRef.get
+      } yield assertTrue(newValue == 30, current == 30)
+    } @@ TestAspect.withLiveClock,
+    test("setIfNotExist should only set when absent") {
+      for {
+        aRef    <- DRef.make("first", ManualId("setIfNotExist-test"))
+        result1 <- aRef.setIfNotExist("second")
+        value   <- aRef.get
+      } yield assertTrue(!result1, value == "first")
+    },
+    test("modifyZIO should work with effectful functions") {
+      for {
+        aRef   <- DRef.make(100, ManualId("modifyZIO-test"))
+        result <- aRef.modifyZIO(v => ZIO.succeed((v.toString, v + 1)))
+        value  <- aRef.get
+      } yield assertTrue(result == "100", value == 101)
+    } @@ TestAspect.withLiveClock,
+    test("updateZIO should work with effectful functions") {
+      for {
+        aRef  <- DRef.make(7, ManualId("updateZIO-test"))
+        _     <- aRef.updateZIO(v => ZIO.succeed(v * 2))
+        value <- aRef.get
+      } yield assertTrue(value == 14)
+    } @@ TestAspect.withLiveClock,
+    test("get on non-existent element should fail") {
+      for {
+        context <- ZIO.service[DRefContext]
+        _       <- context.deleteElement("ghost-element")
+        ref      = new DRefImpl[String](context)("ghost-element")
+        result  <- ref.get.either
+      } yield assertTrue(result.isLeft)
     } @@ TestAspect.withLiveClock
   ).provideSome[Scope](DRefContext.local)
 }

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/DRefGrpcServer.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/DRefGrpcServer.scala
@@ -91,7 +91,7 @@ class DRefGrpcServer(
                     case err                   => new StatusException(io.grpc.Status.INTERNAL.withDescription(err.getMessage))
                   },
                   res =>
-                    if res == null then GetElementResponse(None)
+                    if res.getResult == null then GetElementResponse(None)
                     else GetElementResponse(Option(ByteString.copyFrom(res.getResult)))
                 )
   } yield res

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/DRefStateMachine.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/DRefStateMachine.scala
@@ -62,7 +62,7 @@ class DRefStateMachine(streamBuilder: Sinks.Many[ChangeEvent]) extends StateMach
 
   private def deleteElement(commitIndex: Long, operation: DeleteElementRequest): Option[Array[Byte]] = {
     val res = innerMap.remove(operation.name)
-    streamBuilder.tryEmitNext(DeleteElement(operation.name))
+    streamBuilder.tryEmitNext(DeleteElement(operation.name)).orThrow()
     res.map(_.value)
   }
 

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/DRefStateMachineSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/DRefStateMachineSpec.scala
@@ -2,21 +2,126 @@ package io.github.tobia80.dref.raft
 
 import com.google.protobuf.ByteString
 import io.github.tobia80.dref.*
+import io.github.tobia80.raft.{KVEntry, KVSnapshotChunkData, StartNewTermOpProto}
 import reactor.core.publisher.Sinks
 import zio.*
 import zio.test.{assertTrue, Spec, TestEnvironment, ZIOSpecDefault}
 
+import java.util
+import scala.jdk.CollectionConverters.*
+
 object DRefStateMachineSpec extends ZIOSpecDefault {
 
-  private def makeStateMachine(): DRefStateMachine = {
+  private def makeStateMachine(): (DRefStateMachine, Sinks.Many[ChangeEvent]) = {
     val sink = Sinks.many().multicast().onBackpressureBuffer[ChangeEvent]()
-    new DRefStateMachine(sink)
+    (new DRefStateMachine(sink), sink)
   }
 
   override def spec: Spec[TestEnvironment & Scope, Any] = suite("DRefStateMachine")(
+    suite("setElement")(
+      test("should store a value and emit a change event") {
+        val (sm, sink) = makeStateMachine()
+        val value = ByteString.copyFrom("hello".getBytes)
+        sm.runOperation(1, SetElementRequest(name = "key1", value = value, expireAt = None))
+        val getResult = sm.runOperation(2, GetElementRequest(name = "key1"))
+        assertTrue(
+          getResult != null,
+          java.util.Arrays.equals(getResult.asInstanceOf[Array[Byte]], "hello".getBytes)
+        )
+      },
+      test("should overwrite existing value") {
+        val (sm, _) = makeStateMachine()
+        sm.runOperation(1, SetElementRequest(name = "key1", value = ByteString.copyFrom("first".getBytes), expireAt = None))
+        sm.runOperation(2, SetElementRequest(name = "key1", value = ByteString.copyFrom("second".getBytes), expireAt = None))
+        val getResult = sm.runOperation(3, GetElementRequest(name = "key1")).asInstanceOf[Array[Byte]]
+        assertTrue(java.util.Arrays.equals(getResult, "second".getBytes))
+      },
+      test("should store value with expiration") {
+        val (sm, _) = makeStateMachine()
+        val value = ByteString.copyFrom("expiring".getBytes)
+        sm.runOperation(1, SetElementRequest(name = "key1", value = value, expireAt = Some(5000L)))
+        val table = sm.runOperation(2, GetExpirationTableRequest()).asInstanceOf[Map[String, Long]]
+        assertTrue(table == Map("key1" -> 5000L))
+      }
+    ),
+    suite("getElement")(
+      test("should return null for non-existent key") {
+        val (sm, _) = makeStateMachine()
+        val result = sm.runOperation(1, GetElementRequest(name = "missing"))
+        assertTrue(result == null)
+      },
+      test("should return stored value") {
+        val (sm, _) = makeStateMachine()
+        sm.runOperation(1, SetElementRequest(name = "key1", value = ByteString.copyFrom("data".getBytes), expireAt = None))
+        val result = sm.runOperation(2, GetElementRequest(name = "key1")).asInstanceOf[Array[Byte]]
+        assertTrue(java.util.Arrays.equals(result, "data".getBytes))
+      }
+    ),
+    suite("setElementIfNotExist")(
+      test("should set value when key does not exist") {
+        val (sm, _) = makeStateMachine()
+        val result = sm.runOperation(
+          1,
+          SetElementIfNotExistRequest(name = "key1", value = ByteString.copyFrom("new".getBytes), expireAt = None)
+        )
+        val getResult = sm.runOperation(2, GetElementRequest(name = "key1")).asInstanceOf[Array[Byte]]
+        assertTrue(
+          result == java.lang.Boolean.TRUE,
+          java.util.Arrays.equals(getResult, "new".getBytes)
+        )
+      },
+      test("should not overwrite when key already exists") {
+        val (sm, _) = makeStateMachine()
+        sm.runOperation(1, SetElementRequest(name = "key1", value = ByteString.copyFrom("original".getBytes), expireAt = None))
+        val result = sm.runOperation(
+          2,
+          SetElementIfNotExistRequest(name = "key1", value = ByteString.copyFrom("attempt".getBytes), expireAt = None)
+        )
+        val getResult = sm.runOperation(3, GetElementRequest(name = "key1")).asInstanceOf[Array[Byte]]
+        assertTrue(
+          result == java.lang.Boolean.FALSE,
+          java.util.Arrays.equals(getResult, "original".getBytes)
+        )
+      }
+    ),
+    suite("deleteElement")(
+      test("should remove existing element") {
+        val (sm, _) = makeStateMachine()
+        sm.runOperation(1, SetElementRequest(name = "key1", value = ByteString.copyFrom("data".getBytes), expireAt = None))
+        sm.runOperation(2, DeleteElementRequest(name = "key1"))
+        val getResult = sm.runOperation(3, GetElementRequest(name = "key1"))
+        assertTrue(getResult == null)
+      },
+      test("should return null for deleting non-existent element") {
+        val (sm, _) = makeStateMachine()
+        val result = sm.runOperation(1, DeleteElementRequest(name = "missing"))
+        assertTrue(result == null)
+      }
+    ),
+    suite("expireElement")(
+      test("should set expiration on existing element") {
+        val (sm, _) = makeStateMachine()
+        sm.runOperation(1, SetElementRequest(name = "key1", value = ByteString.copyFrom("data".getBytes), expireAt = None))
+        val result = sm.runOperation(2, ExpireElementRequest(name = "key1", expireAt = 3000L))
+        val table = sm.runOperation(3, GetExpirationTableRequest()).asInstanceOf[Map[String, Long]]
+        assertTrue(result == java.lang.Boolean.TRUE, table == Map("key1" -> 3000L))
+      },
+      test("should return FALSE for non-existent element") {
+        val (sm, _) = makeStateMachine()
+        val result = sm.runOperation(1, ExpireElementRequest(name = "missing", expireAt = 3000L))
+        assertTrue(result == java.lang.Boolean.FALSE)
+      },
+      test("should update existing expiration") {
+        val (sm, _) = makeStateMachine()
+        sm.runOperation(1, SetElementRequest(name = "key1", value = ByteString.copyFrom("data".getBytes), expireAt = Some(1000L)))
+        sm.runOperation(2, ExpireElementRequest(name = "key1", expireAt = 5000L))
+        val table = sm.runOperation(3, GetExpirationTableRequest()).asInstanceOf[Map[String, Long]]
+        assertTrue(table == Map("key1" -> 5000L))
+      }
+    ),
     suite("deleteIfExpired")(
       test("should delete an expired element") {
-        val sm = makeStateMachine()
+        val (sm, _) = makeStateMachine()
         val value = ByteString.copyFrom("hello".getBytes)
         sm.runOperation(1, SetElementRequest(name = "key", value = value, expireAt = Some(1000L)))
         val result = sm.runOperation(2, DeleteIfExpiredRequest("key", expiredBefore = 2000L))
@@ -24,7 +129,7 @@ object DRefStateMachineSpec extends ZIOSpecDefault {
         assertTrue(result != null, getResult == null)
       },
       test("should delete element when expireAt equals expiredBefore") {
-        val sm = makeStateMachine()
+        val (sm, _) = makeStateMachine()
         val value = ByteString.copyFrom("hello".getBytes)
         sm.runOperation(1, SetElementRequest(name = "key", value = value, expireAt = Some(1000L)))
         val result = sm.runOperation(2, DeleteIfExpiredRequest("key", expiredBefore = 1000L))
@@ -32,7 +137,7 @@ object DRefStateMachineSpec extends ZIOSpecDefault {
         assertTrue(result != null, getResult == null)
       },
       test("should not delete a non-expired element") {
-        val sm = makeStateMachine()
+        val (sm, _) = makeStateMachine()
         val value = ByteString.copyFrom("hello".getBytes)
         sm.runOperation(1, SetElementRequest(name = "key", value = value, expireAt = Some(2000L)))
         val result = sm.runOperation(2, DeleteIfExpiredRequest("key", expiredBefore = 1000L))
@@ -40,12 +145,12 @@ object DRefStateMachineSpec extends ZIOSpecDefault {
         assertTrue(result == null, getResult != null)
       },
       test("should return null for non-existent element") {
-        val sm = makeStateMachine()
+        val (sm, _) = makeStateMachine()
         val result = sm.runOperation(1, DeleteIfExpiredRequest("non-existent", expiredBefore = 2000L))
         assertTrue(result == null)
       },
       test("should not delete element without expiration") {
-        val sm = makeStateMachine()
+        val (sm, _) = makeStateMachine()
         val value = ByteString.copyFrom("hello".getBytes)
         sm.runOperation(1, SetElementRequest(name = "key", value = value, expireAt = None))
         val result = sm.runOperation(2, DeleteIfExpiredRequest("key", expiredBefore = 2000L))
@@ -55,7 +160,7 @@ object DRefStateMachineSpec extends ZIOSpecDefault {
     ),
     suite("retrieveExpirationTable")(
       test("should only return elements with expiration") {
-        val sm = makeStateMachine()
+        val (sm, _) = makeStateMachine()
         sm.runOperation(
           1,
           SetElementRequest(name = "with-expiry", value = ByteString.copyFrom("a".getBytes), expireAt = Some(1000L))
@@ -68,13 +173,62 @@ object DRefStateMachineSpec extends ZIOSpecDefault {
         assertTrue(result == Map("with-expiry" -> 1000L))
       },
       test("should return empty map when no elements have expiration") {
-        val sm = makeStateMachine()
+        val (sm, _) = makeStateMachine()
         sm.runOperation(
           1,
           SetElementRequest(name = "no-expiry", value = ByteString.copyFrom("a".getBytes), expireAt = None)
         )
         val result = sm.runOperation(2, GetExpirationTableRequest()).asInstanceOf[Map[String, Long]]
         assertTrue(result.isEmpty)
+      }
+    ),
+    suite("snapshot and restore")(
+      test("takeSnapshot and installSnapshot should preserve state") {
+        val (sm, _) = makeStateMachine()
+        sm.runOperation(1, SetElementRequest(name = "k1", value = ByteString.copyFrom("v1".getBytes), expireAt = Some(1000L)))
+        sm.runOperation(2, SetElementRequest(name = "k2", value = ByteString.copyFrom("v2".getBytes), expireAt = None))
+
+        val chunks = new java.util.ArrayList[AnyRef]()
+        sm.takeSnapshot(2, (chunk: AnyRef) => chunks.add(chunk))
+
+        val (sm2, _) = makeStateMachine()
+        sm2.installSnapshot(2, chunks)
+
+        val v1 = sm2.runOperation(3, GetElementRequest(name = "k1")).asInstanceOf[Array[Byte]]
+        val v2 = sm2.runOperation(4, GetElementRequest(name = "k2")).asInstanceOf[Array[Byte]]
+        val table = sm2.runOperation(5, GetExpirationTableRequest()).asInstanceOf[Map[String, Long]]
+
+        assertTrue(
+          java.util.Arrays.equals(v1, "v1".getBytes),
+          java.util.Arrays.equals(v2, "v2".getBytes),
+          table == Map("k1" -> 1000L)
+        )
+      }
+    ),
+    suite("newTermOperation")(
+      test("getNewTermOperation should return StartNewTermOpProto") {
+        val (sm, _) = makeStateMachine()
+        val result = sm.getNewTermOperation
+        assertTrue(result.isInstanceOf[StartNewTermOpProto])
+      },
+      test("runOperation should handle StartNewTermOpProto without error") {
+        val (sm, _) = makeStateMachine()
+        val result = sm.runOperation(1, StartNewTermOpProto.defaultInstance)
+        assertTrue(result == null)
+      }
+    ),
+    suite("unsupported operations")(
+      test("should throw IllegalArgumentException for unknown operation") {
+        val (sm, _) = makeStateMachine()
+        val result =
+          try {
+            sm.runOperation(1, "unsupported")
+            false
+          } catch {
+            case _: IllegalArgumentException => true
+            case _: Throwable                => false
+          }
+        assertTrue(result)
       }
     )
   )

--- a/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisDRefContext.scala
+++ b/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisDRefContext.scala
@@ -186,12 +186,12 @@ object RedisDRefContext {
       override def setElementIfNotExist(name: String, value: Array[Byte], ttl: Option[Duration]): Task[Boolean] = {
         val change = ChangePayload(name = Chunk.fromArray(name.getBytes), value = Chunk.fromArray(value))
         for {
-          value  <-
+          notification <-
             DRefCodec
               .serializeToArray[ChangePayload](change)
               .mapError(err => new Exception(s"Cannot serialize notification ($change) (Error: ${err.getMessage})"))
-          result <- redisClient.setNx(Chunk.fromArray(name.getBytes), Chunk.fromArray(value), ttl)
-          _      <- publish(Chunk.fromArray(value)).when(result)
+          result       <- redisClient.setNx(Chunk.fromArray(name.getBytes), Chunk.fromArray(value), ttl)
+          _            <- publish(Chunk.fromArray(notification)).when(result)
         } yield result
       }
 
@@ -214,14 +214,12 @@ object RedisDRefContext {
       }
 
       override def detectStolenElement(name: String, value: Array[Byte]): ZStream[Any, Throwable, StolenElement] = {
-        val change = ChangePayload(name = Chunk.fromArray(name.getBytes), value = Chunk.fromArray(value))
         val stolen = for {
-          valueToCheck <-
-            DRefCodec
-              .serializeToArray[ChangePayload](change)
-              .mapError(err => new Exception(s"Cannot serialize notification ($change) (Error: ${err.getMessage})"))
-          result       <- redisClient.get(Chunk.fromArray(name.getBytes))
-        } yield result.forall(el => !util.Arrays.equals(el.toArray, valueToCheck))
+          result <- redisClient.get(Chunk.fromArray(name.getBytes))
+        } yield result match {
+          case Some(currentValue) => !util.Arrays.equals(currentValue.toArray, value)
+          case None               => true
+        }
         ZStream.repeatZIO(stolen.delay(1.second)).filter(identity).as(StolenElement(name))
       }
     }


### PR DESCRIPTION
## Summary

- **RedisDRefContext.setElementIfNotExist**: Fix variable shadowing where `value` binding in the for-comprehension shadowed the method parameter, causing serialized `ChangePayload` bytes to be stored in Redis instead of raw value bytes
- **RedisDRefContext.detectStolenElement**: Compare raw bytes directly against Redis value instead of wrapping in `ChangePayload` first (which always mismatched since Redis stores raw bytes, causing false "stolen" detections)
- **DRefStateMachine.deleteElement**: Add missing `.orThrow()` on `tryEmitNext` to surface emit failures, consistent with `setElement` which already calls `.orThrow()`
- **DRefGrpcServer.getElement**: Fix null check — `res` (the query response wrapper) is never null, but `res.getResult` can be null for non-existent elements, causing NPE

Also adds comprehensive specs for:
- `DRefSpec`: modify, update, getAndUpdate, updateAndGet, setIfNotExist, modifyZIO, updateZIO, get-on-missing-element
- `DRefStateMachineSpec`: setElement, getElement, setElementIfNotExist, deleteElement, expireElement, snapshot/restore, newTermOperation, unsupported operations

## Test plan

- [ ] Verify `dref-core` tests pass (`sbt dref-core/test`)
- [ ] Verify `dref-raft` tests pass (`sbt dref-raft/test`)
- [ ] Verify Redis stolen-lock detection works correctly with a running Redis instance (`sbt dref-redis/test`)
- [ ] Verify `getElement` on non-existent keys no longer throws NPE in raft backend

https://claude.ai/code/session_01VjUaCbsvemHJWi9A8pePYu