### PR TITLE
fix(rust): use named-field msgpack encoding, correct README API examples

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -95,18 +95,31 @@ the rest of your code is unchanged:
 ```rust,ignore
 // Redis backend
 use dref_redis::{RedisConfig, RedisDRefContext};
-let ctx = RedisDRefContext::connect(RedisConfig::default()).await?;
+let ctx = RedisDRefContext::new(RedisConfig {
+    host: "127.0.0.1".into(),
+    port: 6379,
+    database: 0,
+    username: None,
+    password: None,
+    ca_cert: None,
+    ttl: None,
+}).await?;
 
 // Raft backend
 use dref_raft::{NodeEndpoint, RaftConfig, RaftDRefContext};
+use std::time::Duration;
 let ctx = RaftDRefContext::start(RaftConfig {
-    node_id: 1,
-    listen_addr: "0.0.0.0:8082".parse()?,
-    peers: vec![/* NodeEndpoint { id, addr } ... */],
+    port: 8082,
+    bind_address: Some("0.0.0.0:8082".into()),
+    node_id: Some("node-1".into()),
+    initial_endpoints: vec![
+        NodeEndpoint::new("node-1", "127.0.0.1:8082"),
+        // ... other peers
+    ],
     ..Default::default()
-}).await?;
+}, Duration::from_secs(5)).await?;
 
-let ref_value = dref_core::DRef::make(&ctx, || 0).await?;
+let ref_value = dref_core::DRef::make(&ctx, || 0i32).await?;
 ```
 
 Configuration notes:

--- a/rust/dref-core/src/codec.rs
+++ b/rust/dref-core/src/codec.rs
@@ -40,7 +40,10 @@ where
     T: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     fn serialize(&self, value: &T) -> Result<Vec<u8>, DRefError> {
-        rmp_serde::to_vec(value).map_err(|e| DRefError::Serialize(e.to_string()))
+        // Use StructMap encoding (named fields) so the wire-format matches
+        // Scala's zio-schema-msg-pack codec, which encodes case-class fields
+        // as msgpack maps keyed by field name.
+        rmp_serde::to_vec_named(value).map_err(|e| DRefError::Serialize(e.to_string()))
     }
 
     fn deserialize(&self, bytes: &[u8]) -> Result<T, DRefError> {

--- a/rust/dref-redis/src/context.rs
+++ b/rust/dref-redis/src/context.rs
@@ -81,7 +81,8 @@ impl ChangePayload {
         String::from_utf8(self.name.clone()).ok()
     }
     fn encode(&self) -> Result<Vec<u8>, DRefError> {
-        rmp_serde::to_vec(self).map_err(|e| DRefError::Serialize(e.to_string()))
+        // Named-field encoding to match Scala's zio-schema-msg-pack struct maps.
+        rmp_serde::to_vec_named(self).map_err(|e| DRefError::Serialize(e.to_string()))
     }
     fn decode(bytes: &[u8]) -> Result<Self, DRefError> {
         rmp_serde::from_slice(bytes).map_err(|e| DRefError::Deserialize(e.to_string()))


### PR DESCRIPTION
- Switch MsgPackCodec from positional (`to_vec`) to named-field (`to_vec_named`) encoding to match Scala's zio-schema-msg-pack struct-map output. Apply same fix to Redis ChangePayload encode.

- Fix README "Switching backends" snippets which referenced non-existent constructors and config fields.