### PR TITLE
Fix flaky lock tests failing on CI under Redis latency

### DIFF
--- a/dref-core/src/test/scala/io/github/tobia80/dref/DRefSpec.scala
+++ b/dref-core/src/test/scala/io/github/tobia80/dref/DRefSpec.scala
@@ -3,7 +3,7 @@ package io.github.tobia80.dref
 import DRef.*
 import DRef.auto.*
 import zio.test.{assertTrue, Spec, TestAspect, TestClock, TestEnvironment, ZIOSpecDefault}
-import zio.{durationInt, Ref, Scope, ZIO}
+import zio.{durationInt, Promise, Ref, Scope, ZIO}
 
 object DRefSpec extends ZIOSpecDefault {
 
@@ -28,17 +28,22 @@ object DRefSpec extends ZIOSpecDefault {
     test("locks should work") { // two fibers trying to lock the same resource, waiting 1 seconds, queue is written and sleep, when 2 seconds pass, queue is 2 elements
       for {
         list              <- Ref.make[List[Int]](Nil)
+        firstLocked       <- Promise.make[Nothing, Unit]
         fiber             <- ZIO
                                .foreachParDiscard(List(100, 200)) { id =>
                                  (ZIO.logInfo(s"Starting $id") *> DRef
-                                   .lock() {
-                                     ZIO.logInfo(s"Executing $id") *> list.update(_ :+ id) *> ZIO
-                                       .sleep(1.seconds)
+                                   .lock(ManualId("locks-should-work")) {
+                                     for {
+                                       _ <- ZIO.logInfo(s"Executing $id")
+                                       _ <- list.update(_ :+ id)
+                                       _ <- firstLocked.succeed(()).when(id == 100)
+                                       _ <- ZIO.sleep(1.seconds)
+                                     } yield ()
                                    })
                                    .delay(id.millis)
                                }
                                .fork
-        _                 <- ZIO.sleep(500.millis)
+        _                 <- firstLocked.await
         valueWithOneLock  <- list.get
         _                 <- fiber.join
         valueWithTwoLocks <- list.get

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/RaftDRefSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/RaftDRefSpec.scala
@@ -39,17 +39,22 @@ object RaftDRefSpec extends ZIOSpecDefault {
     test("locks should work") { // two fibers trying to lock the same resource, waiting 1 seconds, queue is written and sleep, when 2 seconds pass, queue is 2 elements
       for {
         list              <- Ref.make[List[Int]](Nil)
+        firstLocked       <- Promise.make[Nothing, Unit]
         fiber             <- ZIO
                                .foreachParDiscard(List(100, 200)) { id =>
                                  (ZIO.logInfo(s"Starting $id") *> DRef
-                                   .lock() {
-                                     ZIO.logInfo(s"Executing $id") *> list.update(_ :+ id) *> ZIO
-                                       .sleep(1.seconds)
+                                   .lock(ManualId("locks-should-work")) {
+                                     for {
+                                       _ <- ZIO.logInfo(s"Executing $id")
+                                       _ <- list.update(_ :+ id)
+                                       _ <- firstLocked.succeed(()).when(id == 100)
+                                       _ <- ZIO.sleep(1.seconds)
+                                     } yield ()
                                    })
                                    .delay(id.millis)
                                }
                                .fork
-        _                 <- ZIO.sleep(1000.millis)
+        _                 <- firstLocked.await
         valueWithOneLock  <- list.get
         _                 <- fiber.join
         valueWithTwoLocks <- list.get

--- a/dref-redis/src/test/scala/io/github/tobia80/dref/redis/RedisDRefSpec.scala
+++ b/dref-redis/src/test/scala/io/github/tobia80/dref/redis/RedisDRefSpec.scala
@@ -32,17 +32,22 @@ object RedisDRefSpec extends ZIOSpecDefault {
     test("locks should work") { // two fibers trying to lock the same resource, waiting 1 seconds, queue is written and sleep, when 2 seconds pass, queue is 2 elements
       for {
         list              <- Ref.make[List[Int]](Nil)
+        firstLocked       <- Promise.make[Nothing, Unit]
         fiber             <- ZIO
                                .foreachParDiscard(List(100, 200)) { id =>
                                  (ZIO.logInfo(s"Starting $id") *> DRef
-                                   .lock() {
-                                     ZIO.logInfo(s"Executing $id") *> list.update(_ :+ id) *> ZIO
-                                       .sleep(1.seconds)
+                                   .lock(ManualId("locks-should-work")) {
+                                     for {
+                                       _ <- ZIO.logInfo(s"Executing $id")
+                                       _ <- list.update(_ :+ id)
+                                       _ <- firstLocked.succeed(()).when(id == 100)
+                                       _ <- ZIO.sleep(1.seconds)
+                                     } yield ()
                                    })
                                    .delay(id.millis)
                                }
                                .fork
-        _                 <- ZIO.sleep(500.millis)
+        _                 <- firstLocked.await
         valueWithOneLock  <- list.get
         _                 <- fiber.join
         valueWithTwoLocks <- list.get


### PR DESCRIPTION
## Summary
- Fix the flaky `locks should work` test in `dref-redis` that caused the Scala CI job to fail on GitHub Actions
- Use a shared `ManualId` so both fibers contend for the same lock instead of relying on auto-generated lock keys
- Replace fixed sleeps with a `Promise` that signals when the first lock holder enters the critical section, making ordering assertions deterministic across backends

## Test plan
- [x] `sbt dref-core/testOnly io.github.tobia80.dref.DRefSpec`
- [x] `sbt dref-raft/testOnly io.github.tobia80.dref.raft.RaftDRefSpec -- -t "locks should work"`
- [x] `sbt dref-redis/testOnly io.github.tobia80.dref.redis.RedisDRefSpec`
- [ ] Confirm Scala CI passes on GitHub Actions


Made with [Cursor](https://cursor.com)