### PR TITLE
Reduce ZIO test log noise during sbt test runs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import Dependencies.{zio, zioK8s, sttp}
 
+import sbt.Level
 import scala.collection.Seq
 
 ThisBuild / version := "0.6.6"
@@ -66,6 +67,7 @@ def module(id: String, path: String, description: String): Project =
   Project(id, file(path))
     .settings(moduleName := id, name := description)
     .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
+    .settings(Test / logLevel := Level.Warn)
 
 lazy val `core` = module("dref-core", "dref-core", "Core library")
   .settings(libraryDependencies ++= coreDeps)
@@ -73,13 +75,13 @@ lazy val `core` = module("dref-core", "dref-core", "Core library")
 lazy val example = module("example", "example", "Example app").dependsOn(`core`, raft).settings(noPublishSettings)
 
 lazy val redis = module("dref-redis", "dref-redis", "Redis backend")
-  .dependsOn(`core`)
+  .dependsOn(`core`, `core` % "test->test")
   .settings(
     libraryDependencies ++= redisDeps
   )
 
 lazy val raft = module("dref-raft", "dref-raft", "Raft backend")
-  .dependsOn(`core`)
+  .dependsOn(`core`, `core` % "test->test")
   .settings(
     libraryDependencies ++= raftDeps
   )

--- a/dref-core/src/test/scala/io/github/tobia80/dref/CrossLangCompatSpec.scala
+++ b/dref-core/src/test/scala/io/github/tobia80/dref/CrossLangCompatSpec.scala
@@ -9,7 +9,7 @@ import zio.test.*
 /** Wire-format tests shared with the Rust port. Both sides must agree on these
   * golden bytes for multi-language Redis/Raft clients to interoperate.
   */
-object CrossLangCompatSpec extends ZIOSpecDefault {
+object CrossLangCompatSpec extends QuietZIOSpec {
 
   case class Wrapper(value: String)
   given Schema[Wrapper] = DeriveSchema.gen[Wrapper]

--- a/dref-core/src/test/scala/io/github/tobia80/dref/DRefSpec.scala
+++ b/dref-core/src/test/scala/io/github/tobia80/dref/DRefSpec.scala
@@ -5,7 +5,7 @@ import DRef.auto.*
 import zio.test.{assertTrue, Spec, TestAspect, TestClock, TestEnvironment, ZIOSpecDefault}
 import zio.{durationInt, Promise, Ref, Scope, ZIO}
 
-object DRefSpec extends ZIOSpecDefault {
+object DRefSpec extends QuietZIOSpec {
 
   override def spec: Spec[TestEnvironment & Scope, Any] = suite("DRef memory")(
     test("should be able to create a DRef") {

--- a/dref-core/src/test/scala/io/github/tobia80/dref/QuietZIOSpec.scala
+++ b/dref-core/src/test/scala/io/github/tobia80/dref/QuietZIOSpec.scala
@@ -1,0 +1,15 @@
+package io.github.tobia80.dref
+
+import zio.*
+import zio.test.{TestEnvironment, ZIOSpecDefault, testEnvironment}
+
+/** ZIO test base that suppresses INFO/DEBUG application logs during test runs. */
+trait QuietZIOSpec extends ZIOSpecDefault {
+  private val quietLogging: ZLayer[Any, Nothing, Unit] =
+    Runtime.removeDefaultLoggers >>> Runtime.addLogger(
+      ZLogger.default.filterLogLevel(_ >= LogLevel.Warning)
+    )
+
+  override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
+    quietLogging >>> testEnvironment
+}

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/DRefStateMachineSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/DRefStateMachineSpec.scala
@@ -2,11 +2,12 @@ package io.github.tobia80.dref.raft
 
 import com.google.protobuf.ByteString
 import io.github.tobia80.dref.*
+import io.github.tobia80.dref.QuietZIOSpec
 import reactor.core.publisher.Sinks
 import zio.*
 import zio.test.{assertTrue, Spec, TestEnvironment, ZIOSpecDefault}
 
-object DRefStateMachineSpec extends ZIOSpecDefault {
+object DRefStateMachineSpec extends QuietZIOSpec {
 
   private def makeStateMachine(): DRefStateMachine = {
     val sink = Sinks.many().multicast().onBackpressureBuffer[ChangeEvent]()

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/KubernetesIpProviderSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/KubernetesIpProviderSpec.scala
@@ -6,9 +6,10 @@ import com.coralogix.zio.k8s.model.core.v1.{EndpointAddress, EndpointSubset, End
 import com.coralogix.zio.k8s.model.pkg.apis.meta.v1.ObjectMeta
 import zio.*
 import zio.prelude.data.Optional
-import zio.test.{assertTrue, Spec, TestEnvironment, ZIOSpecDefault}
+import io.github.tobia80.dref.QuietZIOSpec
+import zio.test.{assertTrue, Spec, TestEnvironment}
 
-object KubernetesIpProviderSpec extends ZIOSpecDefault {
+object KubernetesIpProviderSpec extends QuietZIOSpec {
 
   private val serviceName = "my-service"
   private val namespace   = "default"

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/RaftDRefSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/RaftDRefSpec.scala
@@ -1,13 +1,13 @@
 package io.github.tobia80.dref.raft
 
-import io.github.tobia80.dref.{DRef, LockStolenException, ManualId}
+import io.github.tobia80.dref.{DRef, LockStolenException, ManualId, QuietZIOSpec}
 import io.github.tobia80.dref.DRef.*
 import io.github.tobia80.dref.DRef.auto.*
 import io.github.tobia80.dref.raft.RaftDRefContext.RaftDRefContext
 import zio.*
 import zio.test.{assertTrue, Spec, TestAspect, TestEnvironment, ZIOSpecDefault}
 
-object RaftDRefSpec extends ZIOSpecDefault {
+object RaftDRefSpec extends QuietZIOSpec {
 
   override def spec: Spec[TestEnvironment & Scope, Any] = suite("DRef Raft")(
     test("should be able to create a DRef") {
@@ -92,5 +92,5 @@ object RaftDRefSpec extends ZIOSpecDefault {
     ZLayer.succeed(RaftConfig(8082)),
     IpProvider.local,
     Scope.default
-  ) @@ TestAspect.withLiveClock @@ TestAspect.sequential @@ TestAspect.debug
+  ) @@ TestAspect.withLiveClock @@ TestAspect.sequential
 }

--- a/dref-redis/src/test/scala/io/github/tobia80/dref/redis/RedisDRefSpec.scala
+++ b/dref-redis/src/test/scala/io/github/tobia80/dref/redis/RedisDRefSpec.scala
@@ -1,12 +1,12 @@
 package io.github.tobia80.dref.redis
 
-import io.github.tobia80.dref.{DRef, DRefContext, LockStolenException, ManualId}
+import io.github.tobia80.dref.{DRef, DRefContext, LockStolenException, ManualId, QuietZIOSpec}
 import io.github.tobia80.dref.DRef.*
 import io.github.tobia80.dref.DRef.auto.*
 import zio.*
 import zio.test.{assertTrue, Spec, TestAspect, TestEnvironment, ZIOSpecDefault}
 
-object RedisDRefSpec extends ZIOSpecDefault {
+object RedisDRefSpec extends QuietZIOSpec {
 
   case class Wrapper(value: String)
 
@@ -97,5 +97,5 @@ object RedisDRefSpec extends ZIOSpecDefault {
         ttl = Some(5.seconds)
       )
     )
-  ) @@ TestAspect.debug
+  )
 }


### PR DESCRIPTION
## Summary
- Add `QuietZIOSpec` to filter ZIO application logs to Warning+ during tests
- Switch all Scala test specs to use the quiet base and remove `TestAspect.debug`
- Lower sbt test log verbosity and share the test helper via `test->test` deps

## Test plan
- [x] `sbt dref-core/test`
- [x] `sbt dref-raft/test`
- [ ] `sbt test` (full suite with Redis)


Made with [Cursor](https://cursor.com)