### PR TITLE
Add cross-language Scala + Rust Raft interop demo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,34 @@ sets automatically:
   of IP addresses instead of DNS names.
 - `DREF_PORT` — the port used by the gRPC server (defaults to `8082`).
 
+## Run a mixed Scala + Rust cluster locally
+
+For a hands-on demo that Scala and Rust nodes really do participate in the
+same Raft cluster, use the interop example:
+
+```bash
+scripts/interop-cluster.sh up         # build images + start 2 Scala + 1 Rust nodes
+scripts/interop-cluster.sh status     # see the running containers
+scripts/interop-cluster.sh attach scala   # attach to a Scala node
+scripts/interop-cluster.sh attach rust    # attach to the Rust node
+scripts/interop-cluster.sh down       # stop and clean up
+```
+
+Each container reads a display name from stdin and broadcasts chat messages
+through a single `DRef` named `interop-chat-message`. Because both languages
+share the protobuf schemas in [`proto/`](proto/), the MsgPack codec for the
+`DRefMessage(name, message)` record, and a manual id for the key, every node
+sees every message regardless of which language sent it.
+
+The sources of the demo are:
+
+- Scala node: [`interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala`](interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala)
+- Rust node: [`rust/interop-node/src/main.rs`](rust/interop-node/src/main.rs)
+- Compose file: [`docker-compose.interop.yml`](docker-compose.interop.yml)
+- Driver script: [`scripts/interop-cluster.sh`](scripts/interop-cluster.sh)
+
+Override the replica counts with `SCALA_REPLICAS=3 RUST_REPLICAS=2 scripts/interop-cluster.sh up`.
+
 ## License
 
 This project is licensed under the terms of the LICENSE file in this repository.

--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,11 @@ lazy val `core` = module("dref-core", "dref-core", "Core library")
 
 lazy val example = module("example", "example", "Example app").dependsOn(`core`, raft).settings(noPublishSettings)
 
+lazy val interopExample = module("interop-example", "interop-example", "Interop example")
+  .enablePlugins(JavaAppPackaging)
+  .dependsOn(`core`, raft)
+  .settings(noPublishSettings)
+
 lazy val redis = module("dref-redis", "dref-redis", "Redis backend")
   .dependsOn(`core`, `core` % "test->test")
   .settings(
@@ -90,7 +95,7 @@ lazy val raft = module("dref-raft", "dref-raft", "Raft backend")
     Compile / PB.protoSources := Seq(baseDirectory.value.getParentFile / "proto")
   )
 
-aggregateProjects(`core`, redis, raft, example)
+aggregateProjects(`core`, redis, raft, example, interopExample)
 
 // NativePackager settings
 enablePlugins(UniversalPlugin)

--- a/docker-compose.interop.yml
+++ b/docker-compose.interop.yml
@@ -1,0 +1,51 @@
+# Cross-language DRef interop demo: a mixed Scala + Rust Raft cluster.
+#
+# Both services share the `dref-interop` network alias, so each container's
+# `DREF_NODE_SERVICES=dref-interop` resolves to every replica's IP regardless
+# of language. The shared protobuf services + MsgPack codec let Scala and
+# Rust nodes replicate the same Raft log entries and read/write the same
+# `interop-chat-message` DRef.
+#
+# Replica counts are passed by `scripts/interop-cluster.sh` via `--scale`.
+
+services:
+  scala-node:
+    build:
+      context: .
+      dockerfile: docker/interop-scala.Dockerfile
+    image: dref-interop-scala:local
+    environment:
+      DREF_NODE_SERVICES: dref-interop
+      DREF_PORT: "8082"
+      DREF_NODE_LABEL: scala
+    expose:
+      - "8082"
+    stdin_open: true
+    tty: true
+    networks:
+      dref-interop:
+        aliases:
+          - dref-interop
+
+  rust-node:
+    build:
+      context: .
+      dockerfile: docker/interop-rust.Dockerfile
+    image: dref-interop-rust:local
+    environment:
+      DREF_NODE_SERVICES: dref-interop
+      DREF_PORT: "8082"
+      DREF_NODE_LABEL: rust
+      RUST_LOG: "warn,dref_raft=info,interop_node=info"
+    expose:
+      - "8082"
+    stdin_open: true
+    tty: true
+    networks:
+      dref-interop:
+        aliases:
+          - dref-interop
+
+networks:
+  dref-interop:
+    driver: bridge

--- a/docker/interop-rust.Dockerfile
+++ b/docker/interop-rust.Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.6
+# Rust node for the cross-language DRef interop demo.
+# Used by docker-compose.interop.yml together with docker/interop-scala.Dockerfile.
+
+FROM rust:1-bookworm AS build
+WORKDIR /app
+
+# protoc is required by tonic-prost-build (dref-raft compiles protobuf schemas).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# Cargo workspace + crates needed to build interop-node.
+COPY rust/Cargo.toml rust/Cargo.lock ./rust/
+COPY rust/dref-core ./rust/dref-core
+COPY rust/dref-raft ./rust/dref-raft
+COPY rust/dref-redis ./rust/dref-redis
+COPY rust/examples ./rust/examples
+COPY rust/interop-node ./rust/interop-node
+
+# The protobuf definitions live at the repo root and are referenced by
+# rust/dref-raft/build.rs as `../proto/...`.
+COPY proto ./proto
+
+WORKDIR /app/rust
+RUN cargo build --release -p interop-node
+
+FROM debian:bookworm-slim
+WORKDIR /opt/dref
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /app/rust/target/release/interop-node /usr/local/bin/interop-node
+ENV DREF_PORT=8082
+EXPOSE 8082
+ENTRYPOINT ["interop-node"]

--- a/docker/interop-scala.Dockerfile
+++ b/docker/interop-scala.Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.6
+# Scala node for the cross-language DRef interop demo.
+# Used by docker-compose.interop.yml together with docker/interop-rust.Dockerfile.
+
+FROM sbtscala/scala-sbt:eclipse-temurin-21.0.5_11_1.10.8_3.5.1 AS build
+WORKDIR /app
+
+# Project + dependency definitions first to maximise layer caching.
+COPY project ./project
+COPY build.sbt .
+COPY sonatype.sbt .
+
+# Sources required to compile the interop-example module.
+COPY dref-core ./dref-core
+COPY dref-raft ./dref-raft
+COPY dref-redis ./dref-redis
+COPY example ./example
+COPY interop-example ./interop-example
+COPY proto ./proto
+COPY README.md ./
+COPY LICENSE ./
+
+RUN sbt "interop-example/stage"
+
+FROM eclipse-temurin:21-jre
+WORKDIR /opt/dref
+COPY --from=build /app/interop-example/target/universal/stage/ ./
+ENV JAVA_OPTS="-Xms256m -Xmx512m" \
+    DREF_PORT=8082
+EXPOSE 8082
+ENTRYPOINT ["bin/interop-example"]

--- a/interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala
+++ b/interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala
@@ -1,0 +1,97 @@
+package io.tobia80.dref
+
+import io.github.tobia80.dref.DRef.msgpack.{*, given}
+import io.github.tobia80.dref.raft.{IpProvider, RaftConfig, RaftDRefContext}
+import io.github.tobia80.dref.{DRef, ManualId}
+import zio.*
+
+import scala.Console.{BLUE, CYAN, GREEN, RESET, YELLOW}
+
+/** Cross-language interop demo: a Scala Raft node that joins the same cluster as the Rust `interop-node` binary under
+  * `rust/interop-node`.
+  *
+  * Both sides agree on:
+  *
+  *   - the protobuf services from `proto/dref_consensus.proto` and `proto/dref.proto` (Raft replication is
+  *     wire-compatible);
+  *   - the MsgPack named-map encoding for `DRefMessage` (zio-schema-msg-pack on Scala produces the same bytes as
+  *     rmp-serde on Rust for a struct of two `String` fields);
+  *   - the manual id `interop-chat-message`, so the key is looked up in the same Raft log slot regardless of language.
+  *
+  * Driven by the standard `DREF_*` env vars (see `docker-compose.interop.yml`).
+  */
+object InteropMain extends ZIOAppDefault {
+
+  /** Field names + order must stay aligned with the Rust definition. */
+  private case class DRefMessage(name: String, message: String)
+
+  private val SharedKey = "interop-chat-message"
+  private val DefaultPort = 8082
+
+  private val raftConfigLayer: ZLayer[Any, Nothing, RaftConfig] = {
+    val port = sys.env.get("DREF_PORT").flatMap(_.toIntOption).getOrElse(DefaultPort)
+    ZLayer.succeed(RaftConfig(port))
+  }
+
+  private val ipProviderLayer: ZLayer[Any, Throwable, IpProvider] = {
+    def parse(name: String): Option[Seq[String]] =
+      sys.env
+        .get(name)
+        .map(_.split(',').map(_.trim).filter(_.nonEmpty).toSeq)
+        .filter(_.nonEmpty)
+
+    (for {
+      service   <- sys.env.get("DREF_K8S_SERVICE")
+      namespace <- sys.env.get("DREF_K8S_NAMESPACE")
+    } yield IpProvider.k8s(service, namespace))
+      .orElse(parse("DREF_NODE_ADDRESSES").map(addresses => IpProvider.static(addresses*)))
+      .orElse(parse("DREF_NODE_SERVICES").map(services => IpProvider.dnsBased(services*)))
+      .getOrElse(IpProvider.local)
+  }
+
+  private val nodeLabel: String = {
+    val role = sys.env.getOrElse("DREF_NODE_LABEL", "scala")
+    val host = sys.env.get("HOSTNAME").getOrElse("unknown")
+    s"$role/$host"
+  }
+
+  private def chat(displayName: String) =
+    for {
+      dref <- DRef.make[DRefMessage](DRefMessage("", ""), ManualId(SharedKey))
+      _    <- Console.printLine(
+                s"$GREEN[$nodeLabel] joined cluster as '$displayName'. Type messages, 'exit' to quit.$RESET"
+              )
+      _    <- dref.onChange { msg =>
+                Console
+                  .printLine(s"$CYAN<<< (${msg.name}) ${msg.message} [seen by $nodeLabel]$RESET")
+                  .when(msg.name.nonEmpty && msg.name != displayName)
+              }
+      _    <- ZIO.iterate("")(_.toLowerCase != "exit") { _ =>
+                for {
+                  _       <- Console.print(s"$BLUE[$displayName] message ('exit' to quit): $RESET")
+                  message <- Console.readLine
+                  trimmed  = Option(message).map(_.trim).getOrElse("")
+                  _       <- dref
+                               .set(DRefMessage(displayName, trimmed))
+                               .when(trimmed.nonEmpty && trimmed.toLowerCase != "exit")
+                } yield trimmed
+              }
+    } yield ()
+
+  override def run = {
+    val program =
+      for {
+        _     <- Console.print(s"$YELLOW[$nodeLabel] enter your display name: $RESET")
+        name0 <- Console.readLine
+        name   = Option(name0).map(_.trim).filter(_.nonEmpty).getOrElse(nodeLabel)
+        _     <- chat(name)
+      } yield ()
+
+    program.provide(
+      RaftDRefContext.live,
+      raftConfigLayer,
+      ipProviderLayer,
+      Scope.default
+    )
+  }
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1093,6 +1093,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "interop-node"
+version = "0.1.0"
+dependencies = [
+ "dref-core",
+ "dref-raft",
+ "futures",
+ "serde",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1355,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -2542,10 +2564,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "dref-redis",
     "dref-raft",
     "examples",
+    "interop-node",
 ]
 
 [workspace.package]

--- a/rust/interop-node/Cargo.toml
+++ b/rust/interop-node/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "interop-node"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Rust Raft node for the cross-language DRef interop demo"
+publish = false
+
+[[bin]]
+name = "interop-node"
+path = "src/main.rs"
+
+[dependencies]
+dref-core = { path = "../dref-core" }
+dref-raft = { path = "../dref-raft" }
+tokio = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rust/interop-node/src/main.rs
+++ b/rust/interop-node/src/main.rs
@@ -1,0 +1,150 @@
+//! Rust Raft node for the cross-language DRef interop demo.
+//!
+//! Joins the same cluster as the Scala `InteropMain` nodes
+//! (`interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala`):
+//!
+//!   - the shared protobuf services in `proto/dref_consensus.proto` and
+//!     `proto/dref.proto` make Raft replication wire-compatible;
+//!   - the MsgPack `DRefMessage` struct below has the same field names and
+//!     order as the Scala case class, so rmp-serde and
+//!     zio-schema-msg-pack produce identical bytes;
+//!   - the manual id `interop-chat-message` matches the Scala side so both
+//!     languages target the same Raft log entry.
+//!
+//! Driven by the same `DREF_*` env vars as the Scala example
+//! (see `docker-compose.interop.yml`).
+use std::env;
+use std::io::Write;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dref_core::DRef;
+use dref_raft::{RaftConfig, RaftDRefContext};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+const SHARED_KEY: &str = "interop-chat-message";
+
+/// Field names + order must stay aligned with the Scala `DRefMessage` case class.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct DRefMessage {
+    name: String,
+    message: String,
+}
+
+fn node_label() -> String {
+    let role = env::var("DREF_NODE_LABEL").unwrap_or_else(|_| "rust".to_string());
+    let host = env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string());
+    format!("{role}/{host}")
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("warn,dref_raft=info,interop_node=info")
+            }),
+        )
+        .init();
+
+    let label = node_label();
+    let port: u16 = env::var("DREF_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8082);
+
+    // `RaftDRefContext::start` honours the standard `DREF_NODE_SERVICES`,
+    // `DREF_NODE_ADDRESSES`, and `DREF_K8S_*` env vars (see
+    // `dref_raft::ip_provider::from_env`) when `initial_endpoints` is empty.
+    let config = RaftConfig {
+        port,
+        ..Default::default()
+    };
+
+    println!("[{label}] joining Raft cluster on :{port} ...");
+    let ctx = RaftDRefContext::start(config, Duration::from_secs(60)).await?;
+    println!(
+        "[{label}] joined as node_id={} (leader so far: {:?})",
+        ctx.node_id(),
+        ctx.leader_id().await
+    );
+
+    let dref = Arc::new(
+        DRef::make_with_name(&ctx, SHARED_KEY, || DRefMessage {
+            name: String::new(),
+            message: String::new(),
+        })
+        .await?,
+    );
+
+    let mut stdin = BufReader::new(tokio::io::stdin());
+
+    print!("\x1b[33m[{label}] enter your display name: \x1b[0m");
+    std::io::stdout().flush().ok();
+    let mut buf = String::new();
+    if stdin.read_line(&mut buf).await? == 0 {
+        return Ok(());
+    }
+    let display_name = match buf.trim() {
+        "" => label.clone(),
+        s => s.to_string(),
+    };
+
+    println!(
+        "\x1b[32m[{label}] joined as '{display_name}'. Type messages, 'exit' to quit.\x1b[0m"
+    );
+
+    // Listener task: log changes from other nodes.
+    let listener = {
+        let me = display_name.clone();
+        let dref = Arc::clone(&dref);
+        let label = label.clone();
+        tokio::spawn(async move {
+            let mut stream = Box::pin(dref.change_stream());
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(msg) if !msg.name.is_empty() && msg.name != me => {
+                        println!(
+                            "\x1b[36m<<< ({}) {} [seen by {}]\x1b[0m",
+                            msg.name, msg.message, label
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => eprintln!("change stream error: {e}"),
+                }
+            }
+        })
+    };
+
+    loop {
+        print!("\x1b[34m[{display_name}] message ('exit' to quit): \x1b[0m");
+        std::io::stdout().flush().ok();
+        let mut line = String::new();
+        let n = stdin.read_line(&mut line).await?;
+        if n == 0 {
+            break;
+        }
+        let trimmed = line.trim();
+        if trimmed.eq_ignore_ascii_case("exit") {
+            break;
+        }
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Err(e) = dref
+            .set(DRefMessage {
+                name: display_name.clone(),
+                message: trimmed.to_string(),
+            })
+            .await
+        {
+            eprintln!("failed to send message: {e}");
+        }
+    }
+
+    listener.abort();
+    println!("[{label}] exiting.");
+    Ok(())
+}

--- a/scripts/interop-cluster.sh
+++ b/scripts/interop-cluster.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Drive the cross-language DRef interop cluster (2 Scala + 1 Rust Raft nodes)
+# defined in docker-compose.interop.yml.
+#
+# Usage:
+#   scripts/interop-cluster.sh up        # build images and start the cluster
+#   scripts/interop-cluster.sh status    # list containers + show current leader
+#   scripts/interop-cluster.sh logs      # follow logs from every node
+#   scripts/interop-cluster.sh attach N  # attach to scala-node-N or rust-node-N
+#   scripts/interop-cluster.sh attach rust|scala
+#   scripts/interop-cluster.sh down      # stop and remove containers + network
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+COMPOSE_FILE="docker-compose.interop.yml"
+PROJECT_NAME="dref-interop"
+SCALA_REPLICAS="${SCALA_REPLICAS:-2}"
+RUST_REPLICAS="${RUST_REPLICAS:-1}"
+
+dc() {
+  docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" "$@"
+}
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "error: docker is required but not on PATH" >&2
+    exit 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "error: 'docker compose' plugin is required (v2)." >&2
+    exit 1
+  fi
+}
+
+cmd_up() {
+  require_docker
+  echo "==> building Scala + Rust images (first run takes a few minutes)"
+  dc build
+  echo "==> starting cluster: $SCALA_REPLICAS Scala node(s) + $RUST_REPLICAS Rust node(s)"
+  dc up -d --no-build \
+    --scale "scala-node=${SCALA_REPLICAS}" \
+    --scale "rust-node=${RUST_REPLICAS}"
+
+  echo
+  echo "==> cluster is starting. Give Raft a few seconds to elect a leader,"
+  echo "    then attach to a node to chat:"
+  echo
+  echo "    scripts/interop-cluster.sh status"
+  echo "    scripts/interop-cluster.sh attach scala   # any Scala node"
+  echo "    scripts/interop-cluster.sh attach rust    # the Rust node"
+  echo "    scripts/interop-cluster.sh attach 1       # specific replica (1-based)"
+  echo "    scripts/interop-cluster.sh logs           # follow all logs"
+  echo
+  echo "Detach from an attached container with Ctrl-p Ctrl-q (keeps it running)."
+  echo "Stop everything with: scripts/interop-cluster.sh down"
+}
+
+cmd_down() {
+  require_docker
+  echo "==> stopping cluster and removing containers + network"
+  dc down --remove-orphans
+}
+
+cmd_status() {
+  require_docker
+  echo "==> containers:"
+  dc ps
+  echo
+  echo "==> tail of recent logs (last 5 lines per node):"
+  dc logs --tail 5 || true
+}
+
+cmd_logs() {
+  require_docker
+  dc logs -f
+}
+
+pick_container() {
+  # Resolve the user's "scala", "rust", or "<n>" argument into a container name.
+  local target="$1"
+  local -a scala_ids rust_ids
+  mapfile -t scala_ids < <(dc ps -q scala-node)
+  mapfile -t rust_ids  < <(dc ps -q rust-node)
+
+  resolve() {
+    docker inspect --format '{{.Name}}' "$1" 2>/dev/null | sed 's#^/##'
+  }
+
+  case "$target" in
+    scala)
+      [ "${#scala_ids[@]}" -gt 0 ] || { echo "no scala-node containers running" >&2; return 1; }
+      resolve "${scala_ids[0]}"
+      ;;
+    rust)
+      [ "${#rust_ids[@]}" -gt 0 ] || { echo "no rust-node containers running" >&2; return 1; }
+      resolve "${rust_ids[0]}"
+      ;;
+    ''|*[!0-9]*)
+      echo "unknown target '$target' (use 'scala', 'rust', or a 1-based index)" >&2
+      return 1
+      ;;
+    *)
+      local idx=$((target - 1))
+      local -a all_ids=("${scala_ids[@]}" "${rust_ids[@]}")
+      if [ "$idx" -lt 0 ] || [ "$idx" -ge "${#all_ids[@]}" ]; then
+        echo "index $target out of range (1..${#all_ids[@]})" >&2
+        return 1
+      fi
+      resolve "${all_ids[$idx]}"
+      ;;
+  esac
+}
+
+cmd_attach() {
+  require_docker
+  if [ "$#" -lt 1 ]; then
+    echo "usage: $0 attach <scala|rust|N>" >&2
+    exit 2
+  fi
+  local container
+  container="$(pick_container "$1")"
+  echo "==> attaching to ${container} (detach with Ctrl-p Ctrl-q)"
+  docker attach "$container"
+}
+
+cmd_help() {
+  sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-help}" in
+  up|start)        shift; cmd_up "$@" ;;
+  down|stop)       shift; cmd_down "$@" ;;
+  status|ps)       shift; cmd_status "$@" ;;
+  logs)            shift; cmd_logs "$@" ;;
+  attach)          shift; cmd_attach "$@" ;;
+  help|-h|--help)  cmd_help ;;
+  *)               echo "unknown command: $1" >&2; cmd_help; exit 2 ;;
+esac


### PR DESCRIPTION
Wires a small Scala `interop-example` sbt module and a Rust `interop-node`
crate into a mixed Raft cluster (2 Scala + 1 Rust by default) using the
shared protobuf services and MsgPack codec. Both sides target the same
`interop-chat-message` DRef via a manual id so a message typed into any
node is replicated to every other node regardless of language.
`scripts/interop-cluster.sh` builds the images and drives the lifecycle.

https://claude.ai/code/session_01HTPdqx22UihFLfscqaQHFB