### PR TITLE
Unify Scala and Rust on the proto Raft engine

### DIFF
--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoRaftDRefContext.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoRaftDRefContext.scala
@@ -311,29 +311,36 @@ object ProtoRaftDRefContext {
       def loop(transportAttempts: Int, unknownAttempts: Int): Task[A] =
         for {
           expireAt <- ttlToExpireAt(ttl)
-          leader   <- currentLeader
-          result   <- op(leader, expireAt).foldZIO(
-                        {
-                          case ClientError.NotLeader(_) =>
-                            ZIO.sleep(30.millis) *> loop(0, 0)
-                          case ClientError.Transport(_) if transportAttempts < 40 =>
-                            ZIO.sleep(50.millis) *> loop(transportAttempts + 1, unknownAttempts)
-                          case ClientError.Transport(msg) =>
-                            ZIO.fail(new RuntimeException(s"transport error talking to leader: $msg"))
-                          // Followers learn the leader's random nodeId via
-                          // heartbeats before the alias-refresh fiber maps
-                          // it to a gRPC channel. Wait briefly so refresh
-                          // can catch up, then retry rather than failing
-                          // the caller with a transient routing miss.
-                          case ClientError.UnknownNode(_) if unknownAttempts < 20 =>
-                            ZIO.sleep(100.millis) *> loop(transportAttempts, unknownAttempts + 1)
-                          case ClientError.UnknownNode(target) =>
-                            ZIO.fail(new RuntimeException(s"unknown node id $target"))
-                          case ClientError.Other(msg) =>
-                            ZIO.fail(new RuntimeException(msg))
-                        },
-                        ZIO.succeed(_)
-                      )
+          result   <- currentLeader.either.flatMap {
+                        case Left(_) =>
+                          // Membership changes (add/remove) can leave the cluster
+                          // leaderless for several seconds while peers refresh and
+                          // an election completes — retry like NotLeader.
+                          ZIO.sleep(100.millis) *> loop(transportAttempts, unknownAttempts)
+                        case Right(leader) =>
+                          op(leader, expireAt).foldZIO(
+                            {
+                              case ClientError.NotLeader(_) =>
+                                ZIO.sleep(30.millis) *> loop(0, 0)
+                              case ClientError.Transport(_) if transportAttempts < 40 =>
+                                ZIO.sleep(50.millis) *> loop(transportAttempts + 1, unknownAttempts)
+                              case ClientError.Transport(msg) =>
+                                ZIO.fail(new RuntimeException(s"transport error talking to leader: $msg"))
+                              // Followers learn the leader's random nodeId via
+                              // heartbeats before the alias-refresh fiber maps
+                              // it to a gRPC channel. Wait briefly so refresh
+                              // can catch up, then retry rather than failing
+                              // the caller with a transient routing miss.
+                              case ClientError.UnknownNode(_) if unknownAttempts < 20 =>
+                                ZIO.sleep(100.millis) *> loop(transportAttempts, unknownAttempts + 1)
+                              case ClientError.UnknownNode(target) =>
+                                ZIO.fail(new RuntimeException(s"unknown node id $target"))
+                              case ClientError.Other(msg) =>
+                                ZIO.fail(new RuntimeException(msg))
+                            },
+                            ZIO.succeed(_)
+                          )
+                      }
         } yield result
       loop(0, 0)
     }

--- a/interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala
+++ b/interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala
@@ -134,7 +134,13 @@ object InteropMain extends ZIOAppDefault {
                   now <- Clock.currentDateTime
                   msg  = s"hello @${now.toLocalTime}"
                   _   <- Console.printLine(s"$BLUE[$displayName] >>> $msg$RESET")
-                  _   <- dref.set(DRefMessage(displayName, msg))
+                  _   <- dref
+                           .set(DRefMessage(displayName, msg))
+                           .catchAll(err =>
+                             Console.printLineError(
+                               s"[$displayName] failed to send message: ${err.getMessage}"
+                             )
+                           )
                 } yield ()).schedule(Schedule.spaced(interval)).forever
     } yield ()
 


### PR DESCRIPTION
## Summary

- Replace the legacy Scala Microraft stack with the shared protobuf Raft engine (`io.github.tobia80.dref.raft.proto`) so Scala and Rust nodes can join the same cluster and replicate the same log entries.
- Add durable voter-state persistence (cross-language golden vectors + file store) and runtime peer refresh for the interop demo (`scripts/interop-cluster.sh add|remove`).
- Retry Scala client writes when the cluster is briefly leaderless during membership changes; interop auto-demo logs write failures instead of exiting.

## Test plan

- [x] `sbt dref-raft/test dref-core/test`
- [ ] `cd rust && cargo test -p dref-raft -p dref-core`
- [ ] `scripts/interop-cluster.sh up` then `remove scala` / `add scala` — remaining nodes stay up and messages resume after election
- [ ] `sbt test` (Redis integration tests, if Redis available)


Made with [Cursor](https://cursor.com)