### PR TITLE
Simplify interop demo and bump Scala version to 0.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies.{zio, zioK8s, sttp}
 import sbt.Level
 import scala.collection.Seq
 
-ThisBuild / version := "0.6.6"
+ThisBuild / version := "0.7.0"
 
 ThisBuild / scalaVersion := "3.8.3"
 

--- a/interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala
+++ b/interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala
@@ -6,176 +6,102 @@ import io.github.tobia80.dref.raft.proto.{ProtoRaftConfig, ProtoRaftDRefContext}
 import io.github.tobia80.dref.{DRef, DRefContext, ManualId}
 import zio.*
 
-import scala.Console.{BLUE, CYAN, GREEN, RESET, YELLOW}
-
-/** Cross-language interop demo: a Scala Raft node that joins the same cluster as the Rust `interop-node` binary under
-  * `rust/interop-node`.
-  *
-  * Both sides agree on:
-  *
-  *   - the protobuf services from `proto/dref_consensus.proto` and `proto/dref.proto` (Raft replication is
-  *     wire-compatible);
-  *   - the MsgPack named-map encoding for `DRefMessage` (zio-schema-msg-pack on Scala produces the same bytes as
-  *     rmp-serde on Rust for a struct of two `String` fields);
-  *   - the manual id `interop-chat-message`, so the key is looked up in the same Raft log slot regardless of language.
-  *
-  * Driven by the standard `DREF_*` env vars (see `docker-compose.interop.yml`).
-  */
+/** Scala side of the cross-language Raft demo (pairs with `rust/interop-node`). */
 object InteropMain extends ZIOAppDefault {
 
-  /** Field names + order must stay aligned with the Rust definition. */
-  private case class DRefMessage(name: String, message: String)
+  private case class ChatMsg(name: String, message: String)
 
-  private val SharedKey = "interop-chat-message"
-  private val DefaultPort = 8082
-  private val LeaderWait = 60.seconds
+  private val sharedKey = "interop-chat-message"
+  private val port = sys.env.get("DREF_PORT").flatMap(_.toIntOption).getOrElse(8082)
 
-  private val ipProviderLayer: ZLayer[Any, Throwable, IpProvider] = {
-    def parse(name: String): Option[Seq[String]] =
-      sys.env
-        .get(name)
-        .map(_.split(',').map(_.trim).filter(_.nonEmpty).toSeq)
-        .filter(_.nonEmpty)
+  private val label =
+    s"${sys.env.getOrElse("DREF_NODE_LABEL", "scala")}/${sys.env.getOrElse("HOSTNAME", "local")}"
 
+  private def envList(name: String): Option[Seq[String]] =
+    sys.env
+      .get(name)
+      .map(_.split(',').map(_.trim).filter(_.nonEmpty).toSeq)
+      .filter(_.nonEmpty)
+
+  private val ipProviderLayer: ZLayer[Any, Throwable, IpProvider] =
     (for {
       service   <- sys.env.get("DREF_K8S_SERVICE")
       namespace <- sys.env.get("DREF_K8S_NAMESPACE")
     } yield IpProvider.k8s(service, namespace))
-      .orElse(parse("DREF_NODE_ADDRESSES").map(addresses => IpProvider.static(addresses*)))
-      .orElse(parse("DREF_NODE_SERVICES").map(services => IpProvider.dnsBased(services*)))
+      .orElse(envList("DREF_NODE_ADDRESSES").map(IpProvider.static(_*)))
+      .orElse(envList("DREF_NODE_SERVICES").map(IpProvider.dnsBased(_*)))
       .getOrElse(IpProvider.local)
-  }
 
-  /** Builds a [[ProtoRaftDRefContext]] with periodic DNS/k8s peer refresh so
-    * `scripts/interop-cluster.sh add|remove` can resize the cluster at runtime.
-    */
-  private val raftContextLayer: ZLayer[IpProvider, Throwable, DRefContext] =
+  private val raftContextLayer =
     ZLayer.scoped {
       for {
         ipProvider <- ZIO.service[IpProvider]
-        port        = sys.env.get("DREF_PORT").flatMap(_.toIntOption).getOrElse(DefaultPort)
         myIp       <- ipProvider.findMyAddress()
-        bindAddress = s"$myIp:$port"
-        config      = ProtoRaftConfig(port = port, bindAddress = Some(bindAddress))
-        ctx        <- ProtoRaftDRefContext.startWithAddressPolling(config, ipProvider, LeaderWait)
+        config      = ProtoRaftConfig(port = port, bindAddress = Some(s"$myIp:$port"))
+        ctx        <- ProtoRaftDRefContext.startWithAddressPolling(config, ipProvider, 60.seconds)
       } yield ctx: DRefContext
     }
 
-  private val nodeLabel: String = {
-    val role = sys.env.getOrElse("DREF_NODE_LABEL", "scala")
-    val host = sys.env.get("HOSTNAME").getOrElse("unknown")
-    s"$role/$host"
+  private def logRemote(me: String)(msg: ChatMsg) =
+    Console
+      .printLine(s"\u001b[36m<<< (${msg.name}) ${msg.message} [$label]\u001b[0m")
+      .when(msg.name.nonEmpty && msg.name != me)
+
+  private def resolveDisplayName: Task[String] =
+    sys.env.get("DREF_AUTO_NAME").map(_.trim).filter(_.nonEmpty) match {
+      case Some(base) =>
+        ZIO.succeed(sys.env.get("HOSTNAME").filter(_.nonEmpty).fold(base)(h => s"$base-${h.take(6)}"))
+      case None       =>
+        Console.print(s"\u001b[33m[$label] display name: \u001b[0m") *>
+          Console.readLine.map(line => Option(line).map(_.trim).filter(_.nonEmpty).getOrElse(label))
+    }
+
+  private def broadcastSchedule: (Duration, Duration) = {
+    val secs = sys.env.get("DREF_AUTO_INTERVAL_SECS").flatMap(_.toIntOption).filter(_ > 0).getOrElse(3)
+    val id = sys.env.get("HOSTNAME").orElse(sys.env.get("DREF_NODE_LABEL")).getOrElse("node")
+    val hash = id.foldLeft(5381L)((h, c) => (h << 5) + h + c.toLong)
+    (math.abs(hash) % (secs * 1000L)).millis -> secs.seconds
   }
 
-  /** djb2 — same formula as the Rust `interop-node` for stagger offsets. */
-  private def identityHash(key: String): Long = {
-    var hash = 5381L
-    for (c <- key) hash = ((hash << 5) + hash) + c.toLong
-    hash
-  }
-
-  /** Per-replica broadcast timing: initial delay + fixed interval.
-    * Stagger spreads first sends across the interval window so replicas
-    * started together do not publish in lockstep. Override with
-    * `DREF_AUTO_INTERVAL_SECS` (default 3). */
-  private def autoDemoTiming: (Duration, Duration) =
-    val intervalSecs =
-      sys.env.get("DREF_AUTO_INTERVAL_SECS").flatMap(_.toIntOption).filter(_ > 0).getOrElse(3)
-    val interval = intervalSecs.seconds
-    val identity =
-      sys.env.get("HOSTNAME").orElse(sys.env.get("DREF_NODE_LABEL")).getOrElse("node")
-    val staggerMs = math.abs(identityHash(identity)) % (intervalSecs * 1000L)
-    (staggerMs.millis, interval)
-
-  private def chat(displayName: String) =
+  private def demo(displayName: String, auto: Boolean) =
     for {
-      dref <- DRef.make[DRefMessage](DRefMessage("", ""), ManualId(SharedKey))
+      dref <- DRef.make[ChatMsg](ChatMsg("", ""), ManualId(sharedKey))
       _    <- Console.printLine(
-                s"$GREEN[$nodeLabel] joined cluster as '$displayName'. Type messages, 'exit' to quit.$RESET"
+                if auto then s"\u001b[32m[$label] auto-demo as '$displayName'\u001b[0m"
+                else s"\u001b[32m[$label] chat as '$displayName' (type exit to quit)\u001b[0m"
               )
-      _    <- dref.onChange { msg =>
-                Console
-                  .printLine(s"$CYAN<<< (${msg.name}) ${msg.message} [seen by $nodeLabel]$RESET")
-                  .when(msg.name.nonEmpty && msg.name != displayName)
+      _    <- dref.onChange(logRemote(displayName))
+      _    <-
+        if auto then {
+          val (stagger, every) = broadcastSchedule
+          ZIO.sleep(stagger) *>
+            (Clock.currentDateTime
+              .flatMap { now =>
+                val msg = s"hello @${now.toLocalTime}"
+                Console.printLine(s"\u001b[34m[$displayName] >>> $msg\u001b[0m") *>
+                  dref.set(ChatMsg(displayName, msg))
+              })
+              .schedule(Schedule.spaced(every))
+              .forever
+        } else {
+          ZIO.iterate("")(_.toLowerCase != "exit") { _ =>
+            Console.print(s"\u001b[34m[$displayName] > \u001b[0m") *>
+              Console.readLine.flatMap { line =>
+                val text = Option(line).map(_.trim).getOrElse("")
+                dref.set(ChatMsg(displayName, text)).when(text.nonEmpty && text.toLowerCase != "exit") *> ZIO.succeed(
+                  text
+                )
               }
-      _    <- ZIO.iterate("")(_.toLowerCase != "exit") { _ =>
-                for {
-                  _       <- Console.print(s"$BLUE[$displayName] message ('exit' to quit): $RESET")
-                  message <- Console.readLine
-                  trimmed  = Option(message).map(_.trim).getOrElse("")
-                  _       <- dref
-                               .set(DRefMessage(displayName, trimmed))
-                               .when(trimmed.nonEmpty && trimmed.toLowerCase != "exit")
-                } yield trimmed
-              }
+          }
+        }
     } yield ()
 
-  /** Non-interactive demo: broadcast a timestamped message every few seconds
-    * and log everything observed. Triggered by `DREF_AUTO_NAME` so the
-    * default compose setup can show the cluster working without `docker
-    * attach`. Logs from `docker compose logs -f` should show messages from
-    * every other node crossing the language boundary. */
-  private def autoDemo(displayName: String) =
-    val (stagger, interval) = autoDemoTiming
-    for {
-      dref <- DRef.make[DRefMessage](DRefMessage("", ""), ManualId(SharedKey))
-      _    <- Console.printLine(
-                s"$GREEN[$nodeLabel] auto-demo joined as '$displayName' — " +
-                  s"first message in ${stagger.toMillis}ms, then every ${interval.toMillis}ms.$RESET"
-              )
-      _    <- dref
-                .onChange { msg =>
-                  Console
-                    .printLine(s"$CYAN<<< (${msg.name}) ${msg.message} [seen by $nodeLabel]$RESET")
-                    .when(msg.name.nonEmpty && msg.name != displayName)
-                }
-      _    <- ZIO.sleep(stagger) *>
-                (for {
-                  now <- Clock.currentDateTime
-                  msg  = s"hello @${now.toLocalTime}"
-                  _   <- Console.printLine(s"$BLUE[$displayName] >>> $msg$RESET")
-                  _   <- dref
-                           .set(DRefMessage(displayName, msg))
-                           .catchAll(err =>
-                             Console.printLineError(
-                               s"[$displayName] failed to send message: ${err.getMessage}"
-                             )
-                           )
-                } yield ()).schedule(Schedule.spaced(interval)).forever
-    } yield ()
-
-  override def run = {
-    val program =
-      for {
-        // Force the Raft engine to materialise BEFORE blocking on stdin —
-        // otherwise the Scala node would only start serving consensus RPCs
-        // once a human types a display name, which never happens in the
-        // compose setup until someone `docker attach`es.
-        ctx     <- ZIO.service[DRefContext]
-        _       <- Console.printLine(s"$GREEN[$nodeLabel] Raft node ready (DRefContext=$ctx).$RESET")
-        // Suffix the auto-name with a short hostname so each replica is
-        // distinguishable in the chat log (otherwise scala-node-1 and
-        // scala-node-2 both publish as "scala-auto" and the receiver
-        // filter hides every Scala-to-Scala message).
-        hostSuffix = sys.env.get("HOSTNAME").map(_.take(6)).filter(_.nonEmpty)
-        autoOpt  = sys.env.get("DREF_AUTO_NAME").map(_.trim).filter(_.nonEmpty).map { base =>
-                     hostSuffix.fold(base)(h => s"$base-$h")
-                   }
-        _       <- autoOpt match {
-                     case Some(name) => autoDemo(name)
-                     case None       =>
-                       for {
-                         _     <- Console.print(s"$YELLOW[$nodeLabel] enter your display name: $RESET")
-                         name0 <- Console.readLine
-                         name   = Option(name0).map(_.trim).filter(_.nonEmpty).getOrElse(nodeLabel)
-                         _     <- chat(name)
-                       } yield ()
-                   }
-      } yield ()
-
-    program.provide(
-      raftContextLayer,
-      ipProviderLayer
-    )
-  }
+  override def run =
+    (for {
+      _    <- ZIO.service[DRefContext]
+      _    <- Console.printLine(s"\u001b[32m[$label] Raft ready on :$port\u001b[0m")
+      name <- resolveDisplayName
+      auto  = sys.env.get("DREF_AUTO_NAME").exists(_.trim.nonEmpty)
+      _    <- demo(name, auto)
+    } yield ()).provide(ipProviderLayer, raftContextLayer)
 }

--- a/rust/interop-node/src/main.rs
+++ b/rust/interop-node/src/main.rs
@@ -1,18 +1,5 @@
-//! Rust Raft node for the cross-language DRef interop demo.
-//!
-//! Joins the same cluster as the Scala `InteropMain` nodes
-//! (`interop-example/src/main/scala/io/tobia80/dref/InteropMain.scala`):
-//!
-//!   - the shared protobuf services in `proto/dref_consensus.proto` and
-//!     `proto/dref.proto` make Raft replication wire-compatible;
-//!   - the MsgPack `DRefMessage` struct below has the same field names and
-//!     order as the Scala case class, so rmp-serde and
-//!     zio-schema-msg-pack produce identical bytes;
-//!   - the manual id `interop-chat-message` matches the Scala side so both
-//!     languages target the same Raft log entry.
-//!
-//! Driven by the same `DREF_*` env vars as the Scala example
-//! (see `docker-compose.interop.yml`).
+//! Rust side of the cross-language Raft demo (pairs with Scala `InteropMain`).
+
 use std::env;
 use std::io::Write;
 use std::sync::Arc;
@@ -26,43 +13,65 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 
 const SHARED_KEY: &str = "interop-chat-message";
 
-/// Field names + order must stay aligned with the Scala `DRefMessage` case class.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct DRefMessage {
+struct ChatMsg {
     name: String,
     message: String,
 }
 
-fn node_label() -> String {
-    let role = env::var("DREF_NODE_LABEL").unwrap_or_else(|_| "rust".to_string());
-    let host = env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string());
+fn label() -> String {
+    let role = env::var("DREF_NODE_LABEL").unwrap_or_else(|_| "rust".into());
+    let host = env::var("HOSTNAME").unwrap_or_else(|_| "local".into());
     format!("{role}/{host}")
 }
 
-/// djb2 — same formula as Scala `InteropMain` for stagger offsets.
-fn identity_hash(key: &str) -> u64 {
-    key.bytes().fold(5381u64, |hash, b| hash.wrapping_mul(33).wrapping_add(u64::from(b)))
+fn display_name(label: &str) -> String {
+    let auto = env::var("DREF_AUTO_NAME").ok().filter(|s| !s.trim().is_empty());
+    match auto {
+        Some(base) => env::var("HOSTNAME")
+            .ok()
+            .filter(|h| !h.is_empty())
+            .map(|h| format!("{}-{}", base.trim(), h.chars().take(6).collect::<String>()))
+            .unwrap_or_else(|| base.trim().to_string()),
+        None => label.to_string(),
+    }
 }
 
-/// Per-replica broadcast timing: initial delay + fixed interval.
-/// Stagger spreads first sends across the interval window so replicas
-/// started together do not publish in lockstep. Override with
-/// `DREF_AUTO_INTERVAL_SECS` (default 3).
-fn auto_demo_timing() -> (Duration, Duration) {
-    let interval_secs: u64 = env::var("DREF_AUTO_INTERVAL_SECS")
+fn broadcast_schedule() -> (Duration, Duration) {
+    let secs: u64 = env::var("DREF_AUTO_INTERVAL_SECS")
         .ok()
         .and_then(|v| v.parse().ok())
         .filter(|&n| n > 0)
         .unwrap_or(3);
-    let identity = env::var("HOSTNAME")
+    let id = env::var("HOSTNAME")
         .or_else(|_| env::var("DREF_NODE_LABEL"))
-        .unwrap_or_else(|_| "node".to_string());
-    let window_ms = interval_secs.saturating_mul(1000);
-    let stagger_ms = identity_hash(&identity) % window_ms;
+        .unwrap_or_else(|_| "node".into());
+    let hash = id.bytes().fold(5381u64, |h, b| h.wrapping_mul(33).wrapping_add(u64::from(b)));
     (
-        Duration::from_millis(stagger_ms),
-        Duration::from_secs(interval_secs),
+        Duration::from_millis(hash % secs.saturating_mul(1000)),
+        Duration::from_secs(secs),
     )
+}
+
+fn spawn_listener<C>(dref: Arc<DRef<ChatMsg, C>>, me: String, label: String)
+where
+    C: dref_core::DRefContext + Clone + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        let mut stream = Box::pin(dref.change_stream());
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(msg) if !msg.name.is_empty() && msg.name != me => {
+                    println!(
+                        "\x1b[36m<<< ({}) {} [{}]\x1b[0m",
+                        msg.name, msg.message, label
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => eprintln!("change stream error: {e}"),
+            }
+        }
+    });
 }
 
 #[tokio::main(flavor = "multi_thread")]
@@ -75,178 +84,83 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         )
         .init();
 
-    let label = node_label();
+    let label = label();
     let port: u16 = env::var("DREF_PORT")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(8082);
 
-    // `RaftDRefContext::start` honours the standard `DREF_NODE_SERVICES`,
-    // `DREF_NODE_ADDRESSES`, and `DREF_K8S_*` env vars (see
-    // `dref_raft::ip_provider::from_env`) when `initial_endpoints` is empty.
-    let config = RaftConfig {
-        port,
-        ..Default::default()
-    };
-
-    println!("[{label}] joining Raft cluster on :{port} ...");
-    let ctx = RaftDRefContext::start(config, Duration::from_secs(60)).await?;
-    println!(
-        "[{label}] joined as node_id={} (leader so far: {:?})",
-        ctx.node_id(),
-        ctx.leader_id().await
-    );
+    println!("\x1b[32m[{label}] joining on :{port} ...\x1b[0m");
+    let ctx = RaftDRefContext::start(RaftConfig { port, ..Default::default() }, Duration::from_secs(60)).await?;
+    println!("\x1b[32m[{label}] Raft ready (node_id={})\x1b[0m", ctx.node_id());
 
     let dref = Arc::new(
-        DRef::make_with_name(&ctx, SHARED_KEY, || DRefMessage {
+        DRef::make_with_name(&ctx, SHARED_KEY, || ChatMsg {
             name: String::new(),
             message: String::new(),
         })
         .await?,
     );
 
-    // Non-interactive demo path: when DREF_AUTO_NAME is set, broadcast a
-    // timestamped message every few seconds and log everything observed.
-    // This is what the default compose setup uses so `docker compose logs -f`
-    // shows the cluster working without anyone having to `docker attach`.
-    if let Some(auto_name) = env::var("DREF_AUTO_NAME").ok().filter(|s| !s.trim().is_empty()) {
-        // Suffix the auto-name with a short hostname so each replica is
-        // distinguishable in the chat log — without this, two rust-node
-        // replicas both publish as "rust-auto" and the receiver filter
-        // hides every Rust-to-Rust message.
-        let base = auto_name.trim().to_string();
-        let display_name = match env::var("HOSTNAME").ok().filter(|s| !s.is_empty()) {
-            Some(h) => format!("{base}-{}", h.chars().take(6).collect::<String>()),
-            None => base,
-        };
-        return run_auto_demo(dref, label, display_name).await;
-    }
-
-    let mut stdin = BufReader::new(tokio::io::stdin());
-
-    print!("\x1b[33m[{label}] enter your display name: \x1b[0m");
-    std::io::stdout().flush().ok();
-    let mut buf = String::new();
-    if stdin.read_line(&mut buf).await? == 0 {
-        return Ok(());
-    }
-    let display_name = match buf.trim() {
-        "" => label.clone(),
-        s => s.to_string(),
-    };
-
-    println!(
-        "\x1b[32m[{label}] joined as '{display_name}'. Type messages, 'exit' to quit.\x1b[0m"
-    );
-
-    // Listener task: log changes from other nodes.
-    let listener = {
-        let me = display_name.clone();
-        let dref = Arc::clone(&dref);
-        let label = label.clone();
-        tokio::spawn(async move {
-            let mut stream = Box::pin(dref.change_stream());
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(msg) if !msg.name.is_empty() && msg.name != me => {
-                        println!(
-                            "\x1b[36m<<< ({}) {} [seen by {}]\x1b[0m",
-                            msg.name, msg.message, label
-                        );
-                    }
-                    Ok(_) => {}
-                    Err(e) => eprintln!("change stream error: {e}"),
-                }
-            }
-        })
-    };
-
-    loop {
-        print!("\x1b[34m[{display_name}] message ('exit' to quit): \x1b[0m");
+    let auto = env::var("DREF_AUTO_NAME").ok().is_some_and(|s| !s.trim().is_empty());
+    let name = if auto {
+        display_name(&label)
+    } else {
+        print!("\x1b[33m[{label}] display name: \x1b[0m");
         std::io::stdout().flush().ok();
-        let mut line = String::new();
-        let n = stdin.read_line(&mut line).await?;
-        if n == 0 {
-            break;
-        }
-        let trimmed = line.trim();
-        if trimmed.eq_ignore_ascii_case("exit") {
-            break;
-        }
-        if trimmed.is_empty() {
-            continue;
-        }
-        if let Err(e) = dref
-            .set(DRefMessage {
-                name: display_name.clone(),
-                message: trimmed.to_string(),
-            })
-            .await
-        {
-            eprintln!("failed to send message: {e}");
-        }
-    }
+        let mut buf = String::new();
+        BufReader::new(tokio::io::stdin()).read_line(&mut buf).await?;
+        let trimmed = buf.trim();
+        if trimmed.is_empty() { label.clone() } else { trimmed.to_string() }
+    };
 
-    listener.abort();
-    println!("[{label}] exiting.");
-    Ok(())
-}
-
-async fn run_auto_demo<C>(
-    dref: Arc<DRef<DRefMessage, C>>,
-    label: String,
-    display_name: String,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
-where
-    C: dref_core::DRefContext + Clone + Send + Sync + 'static,
-{
-    let (stagger, interval) = auto_demo_timing();
     println!(
-        "\x1b[32m[{label}] auto-demo joined as '{display_name}' — \
-         first message in {stagger:?}, then every {interval:?}.\x1b[0m"
+        "\x1b[32m[{label}] {} as '{name}'\x1b[0m",
+        if auto { "auto-demo" } else { "chat (type exit to quit)" }
     );
 
-    // Listener task.
-    {
-        let me = display_name.clone();
-        let dref = Arc::clone(&dref);
-        let label = label.clone();
-        tokio::spawn(async move {
-            let mut stream = Box::pin(dref.change_stream());
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(msg) if !msg.name.is_empty() && msg.name != me => {
-                        println!(
-                            "\x1b[36m<<< ({}) {} [seen by {}]\x1b[0m",
-                            msg.name, msg.message, label
-                        );
-                    }
-                    Ok(_) => {}
-                    Err(e) => eprintln!("change stream error: {e}"),
-                }
-            }
-        });
-    }
+    spawn_listener(Arc::clone(&dref), name.clone(), label.clone());
 
-    let start = tokio::time::Instant::now() + stagger;
-    let mut tick = tokio::time::interval_at(start, interval);
-    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    loop {
-        tick.tick().await;
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        let message = format!("hello @t={now}");
-        println!("\x1b[34m[{display_name}] >>> {message}\x1b[0m");
-        if let Err(e) = dref
-            .set(DRefMessage {
-                name: display_name.clone(),
+    if auto {
+        let (stagger, every) = broadcast_schedule();
+        let start = tokio::time::Instant::now() + stagger;
+        let mut tick = tokio::time::interval_at(start, every);
+        loop {
+            tick.tick().await;
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let message = format!("hello @t={now}");
+            println!("\x1b[34m[{name}] >>> {message}\x1b[0m");
+            dref.set(ChatMsg {
+                name: name.clone(),
                 message,
             })
-            .await
-        {
-            eprintln!("failed to send message: {e}");
+            .await?;
+        }
+    } else {
+        let mut stdin = BufReader::new(tokio::io::stdin());
+        loop {
+            print!("\x1b[34m[{name}] > \x1b[0m");
+            std::io::stdout().flush().ok();
+            let mut line = String::new();
+            if stdin.read_line(&mut line).await? == 0 {
+                break;
+            }
+            let text = line.trim();
+            if text.eq_ignore_ascii_case("exit") {
+                break;
+            }
+            if !text.is_empty() {
+                dref.set(ChatMsg {
+                    name: name.clone(),
+                    message: text.to_string(),
+                })
+                .await?;
+            }
         }
     }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Bump `ThisBuild / version` from 0.6.6 to 0.7.0 for Scala artifacts.
- Simplify the cross-language interop examples: one shared chat/auto flow on each side, shorter logging, and less duplicated listener/broadcast code (~160 net lines removed).

## Test plan

- [ ] `sbt interop-example/compile`
- [ ] `cd rust && cargo build -p interop-node`
- [ ] `scripts/interop-cluster.sh up` and confirm Scala/Rust nodes exchange messages in logs
- [ ] Optional: `scripts/interop-cluster.sh attach scala` for interactive chat


Made with [Cursor](https://cursor.com)