### PR TITLE
Apply ZIO idioms across Scala backends

### DIFF
--- a/dref-core/src/main/scala/io/github/tobia80/dref/DRef.scala
+++ b/dref-core/src/main/scala/io/github/tobia80/dref/DRef.scala
@@ -22,6 +22,7 @@ import zio.{
   Scope,
   Task,
   Trace,
+  UIO,
   ZIO,
   ZLayer
 }
@@ -58,25 +59,13 @@ trait DRef[T] {
     }
 
   def getAndUpdateZIO[C](f: T => RIO[C, T]): RIO[C, T] =
-    modifyZIO { v =>
-      for {
-        result <- f(v)
-      } yield (v, result)
-    }
+    modifyZIO(v => f(v).map(result => (v, result)))
 
   def updateZIO[C](f: T => RIO[C, T]): RIO[C, Unit] =
-    modifyZIO { v =>
-      for {
-        result <- f(v)
-      } yield ((), result)
-    }
+    modifyZIO(v => f(v).map(result => ((), result)))
 
   def updateAndGetZIO[C](f: T => RIO[C, T]): RIO[C, T] =
-    modifyZIO { v =>
-      for {
-        result <- f(v)
-      } yield (result, result)
-    }
+    modifyZIO(v => f(v).map(result => (result, result)))
 
 }
 
@@ -117,15 +106,10 @@ private case class ExpiringValue(value: Array[Byte], expireAt: Option[Long])
 
 object DRefContext {
 
-  private def removeExpiredElements(ref: Ref[Map[String, ExpiringValue]]): ZIO[Any, Nothing, Unit] =
-    for {
-      now <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      _   <- ref.update { old =>
-               old.filter { case (_, v) =>
-                 v.expireAt.forall(_ > now)
-               }
-             }
-    } yield ()
+  private def removeExpiredElements(ref: Ref[Map[String, ExpiringValue]]): UIO[Unit] =
+    Clock.currentTime(TimeUnit.MILLISECONDS).flatMap { now =>
+      ref.update(_.filter { case (_, v) => v.expireAt.forall(_ > now) })
+    }
 
   val local: ZLayer[Scope, Nothing, DRefContext] = ZLayer(for {
     ref     <- Ref.make[Map[String, ExpiringValue]](Map.empty)
@@ -320,17 +304,20 @@ object DRef {
                                      .fork
       aliveFiber                <- context.keepAliveStream(name, defaultTtl).interruptWhen(aliveInterruptStream).runDrain.fork
       result                    <- fFiber.await
-                                     .flatMap {
-                                       case zio.Exit.Success(value)                            => ZIO.succeed(value)
-                                       case zio.Exit.Failure(cause) if cause.isInterruptedOnly =>
-                                         stolen.get.flatMap { beenStolen =>
-                                           if beenStolen then
-                                             ZIO.logError(s"Stolen lock ${name} with value $lockValue") *> 
-                                             stolenLockException.await.flatMap(ZIO.fail(_))
-                                           else ZIO.failCause(cause)
-                                         }
-                                       case zio.Exit.Failure(cause)                            => ZIO.failCause(cause)
-                                     }
+                                     .flatMap(
+                                       _.foldCauseZIO(
+                                         cause =>
+                                           if cause.isInterruptedOnly then
+                                             stolen.get.flatMap { beenStolen =>
+                                               if beenStolen then
+                                                 ZIO.logError(s"Stolen lock ${name} with value $lockValue") *>
+                                                   stolenLockException.await.flatMap(ZIO.fail(_))
+                                               else ZIO.failCause(cause)
+                                             }
+                                           else ZIO.failCause(cause),
+                                         ZIO.succeed(_)
+                                       )
+                                     )
                                      .ensuring {
                                        aliveInterruptStream.succeed(()) *> stolenLockInterruptStream.succeed(()) *>
                                          stolen.get.flatMap { hasBeenStolen =>
@@ -375,14 +362,11 @@ case class ManualId(value: String) extends IdProvider
 
 class DRefImpl[T: DRefCodec](context: DRefContext)(name: String) extends DRef[T] {
 
-  override def get: Task[T] = {
-    val result: Task[Option[Array[Byte]]] = context.getElement(name)
-    result.flatMap {
-      case Some(bytes) =>
-        DRefCodec.deserializeFromArray(bytes)
-      case None        => ZIO.fail(new Throwable(s"Element $name not found"))
-    }
-  }
+  override def get: Task[T] =
+    context
+      .getElement(name)
+      .flatMap(ZIO.fromOption(_).orElseFail(new Throwable(s"Element $name not found")))
+      .flatMap(DRefCodec.deserializeFromArray)
 
   override def set(a: T): Task[Unit] = DRefCodec
     .serializeToArray(a)

--- a/dref-core/src/main/scala/io/github/tobia80/dref/LockValue.scala
+++ b/dref-core/src/main/scala/io/github/tobia80/dref/LockValue.scala
@@ -2,9 +2,8 @@ package io.github.tobia80.dref
 
 import java.nio.ByteBuffer
 
-/** Wire format for distributed lock tokens. Both Scala and Rust clients
-  * store lock ownership as an 8-byte big-endian `Long` so mixed-language
-  * clusters can detect stolen locks consistently.
+/** Wire format for distributed lock tokens. Both Scala and Rust clients store lock ownership as an 8-byte big-endian
+  * `Long` so mixed-language clusters can detect stolen locks consistently.
   */
 object LockValue {
 

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/IpProvider.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/IpProvider.scala
@@ -13,8 +13,8 @@ trait IpProvider {
 object IpProvider {
 
   def k8s(
-      serviceName: String,
-      namespace: String
+    serviceName: String,
+    namespace: String
   ): ZLayer[Any, Throwable, IpProvider] =
     KubernetesIpProvider.live(serviceName, namespace)
 
@@ -32,10 +32,8 @@ object IpProvider {
     new IpProvider {
       override def findNodeAddresses(): Task[List[String]] = ZIO.succeed(ips.toList)
 
-      override def findMyAddress(): Task[String] = ZIO.attempt {
-        import java.net.InetAddress
-        InetAddress.getLocalHost.getHostAddress
-      }
+      override def findMyAddress(): Task[String] =
+        ZIO.attemptBlocking(java.net.InetAddress.getLocalHost.getHostAddress)
 
       override def expectedEndpoints: Task[Int] = ZIO.succeed(ips.size)
     }
@@ -43,17 +41,14 @@ object IpProvider {
 
   def dnsBased(services: String*): ZLayer[Any, Nothing, IpProvider] = ZLayer.succeed {
     new IpProvider {
-      override def findNodeAddresses(): Task[List[String]] = ZIO.attempt {
-        import java.net.InetAddress
-        services.flatMap { service =>
-          InetAddress.getAllByName(service).map(_.getHostAddress)
-        }.toList
-      }
+      override def findNodeAddresses(): Task[List[String]] =
+        ZIO.attemptBlocking {
+          import java.net.InetAddress
+          services.flatMap(service => InetAddress.getAllByName(service).map(_.getHostAddress)).toList
+        }
 
-      override def findMyAddress(): Task[String] = ZIO.attempt {
-        import java.net.InetAddress
-        InetAddress.getLocalHost.getHostAddress
-      }
+      override def findMyAddress(): Task[String] =
+        ZIO.attemptBlocking(java.net.InetAddress.getLocalHost.getHostAddress)
 
       override def expectedEndpoints: Task[Int] = findNodeAddresses().map(_.size)
     }

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/KubernetesIpProvider.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/KubernetesIpProvider.scala
@@ -23,15 +23,15 @@ object KubernetesIpProvider {
       .toSet
 
   def live(
-      serviceName: String,
-      namespace: String
+    serviceName: String,
+    namespace: String
   ): ZLayer[Any, Throwable, IpProvider] =
     (k8sDefault >>> Endpointses.live) >>> ZLayer.fromFunction(create(serviceName, namespace, _))
 
   private[raft] def create(
-      serviceName: String,
-      namespace: String,
-      endpointsSvc: Endpointses
+    serviceName: String,
+    namespace: String,
+    endpointsSvc: Endpointses
   ): IpProvider = {
     val k8sNamespace = K8sNamespace(namespace)
     new IpProvider {
@@ -49,13 +49,13 @@ object KubernetesIpProvider {
 
       override def findMyAddress(): Task[String] =
         findNodeAddresses().flatMap { endpointIps =>
-          ZIO.attempt {
-            val myIps = localIps()
-            endpointIps.find(myIps.contains)
-          }.flatMap {
-            case Some(ip) => ZIO.succeed(ip)
-            case None     => ZIO.attempt(InetAddress.getLocalHost.getHostAddress)
-          }
+          ZIO
+            .attemptBlocking(localIps())
+            .flatMap(myIps =>
+              ZIO
+                .fromOption(endpointIps.find(myIps.contains))
+                .orElse(ZIO.attemptBlocking(InetAddress.getLocalHost.getHostAddress))
+            )
         }
 
       override def expectedEndpoints: Task[Int] =

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/GrpcChannels.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/GrpcChannels.scala
@@ -4,6 +4,7 @@ import io.grpc.netty.NettyChannelBuilder
 import scalapb.zio_grpc.ZManagedChannel
 
 object GrpcChannels {
+
   def managedChannel(address: String): ZManagedChannel = {
     val Array(host, port) = address.split(":", 2)
     ZManagedChannel(NettyChannelBuilder.forAddress(host, port.toInt).usePlaintext())

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/NodeEndpoint.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/NodeEndpoint.scala
@@ -3,6 +3,7 @@ package io.github.tobia80.dref.raft.proto
 case class NodeEndpoint(id: String, address: String)
 
 object NodeEndpoint {
+
   def apply(id: String, host: String, port: Int): NodeEndpoint =
     NodeEndpoint(id, s"$host:$port")
 }

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
@@ -12,7 +12,7 @@ enum Role {
   case Follower, Candidate, Leader
 }
 
-private final case class ConsensusState(
+final private case class ConsensusState(
   role: Role,
   term: Long,
   votedFor: Option[String],
@@ -22,10 +22,13 @@ private final case class ConsensusState(
 )
 
 sealed trait ConsensusError extends Throwable
+
 object ConsensusError {
+
   final case class NotLeader(leaderId: Option[String]) extends ConsensusError {
     override def getMessage: String = s"not leader; current leader id = $leaderId"
   }
+
   case object NoLeader extends ConsensusError {
     override def getMessage: String = "no leader is currently elected"
   }
@@ -60,21 +63,18 @@ final class ProtoConsensusEngine private (
                      .scoped(GrpcChannels.managedChannel(ep.address))
                      .map(ep.id -> _)
                  }
-      _ <- peersRef.update(_ ++ added.toMap).when(added.nonEmpty)
+      _       <- peersRef.update(_ ++ added.toMap).when(added.nonEmpty)
     } yield ()
 
-  /** Run a state mutation and, if it changed `term` or `votedFor`, fsync the
-    * new voter state to disk *before* the caller observes the result.
+  /** Run a state mutation and, if it changed `term` or `votedFor`, fsync the new voter state to disk *before* the
+    * caller observes the result.
     *
-    * Raft safety requires that a node never grants a vote or steps up to a
-    * higher term unless that decision is durable: otherwise a crash-restart
-    * loop can produce two leaders in one term. The semaphore serializes
-    * persist calls so the on-disk record matches the in-memory order of
-    * mutations even under concurrent RPCs.
+    * Raft safety requires that a node never grants a vote or steps up to a higher term unless that decision is durable:
+    * otherwise a crash-restart loop can produce two leaders in one term. The semaphore serializes persist calls so the
+    * on-disk record matches the in-memory order of mutations even under concurrent RPCs.
     *
-    * If the configured store throws (disk full, IO error) we `orDie` — a
-    * Raft node that can't durably record its vote has no safe forward path
-    * and the process is expected to crash so the orchestrator restarts it.
+    * If the configured store throws (disk full, IO error) we `orDie` — a Raft node that can't durably record its vote
+    * has no safe forward path and the process is expected to crash so the orchestrator restarts it.
     */
   private def updateAndPersist[A](f: ConsensusState => (A, ConsensusState)): UIO[A] =
     persistMutex.withPermit {
@@ -96,15 +96,17 @@ final class ProtoConsensusEngine private (
 
   def submit(cmd: StateCommand): IO[ConsensusError, ApplyResult] =
     for {
-      termAndSeq <- stateRef.modify { st =>
-                      if st.role != Role.Leader then (Left(ConsensusError.NotLeader(st.leaderId)), st)
-                      else
-                        val next = st.copy(lastSeq = st.lastSeq + 1)
-                        (Right((next.term, next.lastSeq)), next)
-                    }.flatMap {
-                      case Left(err)  => ZIO.fail(err)
-                      case Right(pair) => ZIO.succeed(pair)
-                    }
+      termAndSeq <- stateRef
+                      .modify { st =>
+                        if st.role != Role.Leader then (Left(ConsensusError.NotLeader(st.leaderId)), st)
+                        else
+                          val next = st.copy(lastSeq = st.lastSeq + 1)
+                          (Right((next.term, next.lastSeq)), next)
+                      }
+                      .flatMap {
+                        case Left(err)   => ZIO.fail(err)
+                        case Right(pair) => ZIO.succeed(pair)
+                      }
       (term, seq) = termAndSeq
       bytes       = cmd.toByteArray
       result     <- stateMachine.apply(cmd)
@@ -118,20 +120,20 @@ final class ProtoConsensusEngine private (
     command: Array[Byte]
   ): UIO[(Boolean, Long)] =
     for {
-      updated <- updateAndPersist { st =>
-                   if term < st.term then ((false, st.term), st)
-                   else
-                     val stepped =
-                       if term > st.term then st.copy(term = term, votedFor = None)
-                       else st
-                     val next = stepped.copy(
-                       role = Role.Follower,
-                       leaderId = Some(leaderId),
-                       lastHeartbeatNanos = java.lang.System.nanoTime()
-                     )
-                     if seq != next.lastSeq + 1 then ((false, next.term), next)
-                     else ((true, next.term), next.copy(lastSeq = seq))
-                 }
+      updated                <- updateAndPersist { st =>
+                                  if term < st.term then ((false, st.term), st)
+                                  else
+                                    val stepped =
+                                      if term > st.term then st.copy(term = term, votedFor = None)
+                                      else st
+                                    val next = stepped.copy(
+                                      role = Role.Follower,
+                                      leaderId = Some(leaderId),
+                                      lastHeartbeatNanos = java.lang.System.nanoTime()
+                                    )
+                                    if seq != next.lastSeq + 1 then ((false, next.term), next)
+                                    else ((true, next.term), next.copy(lastSeq = seq))
+                                }
       (accepted, currentTerm) = updated
       result                 <-
         if accepted then
@@ -166,8 +168,8 @@ final class ProtoConsensusEngine private (
           if term > st.term then st.copy(term = term, votedFor = None, role = Role.Follower)
           else st
         val upToDate = lastSeq >= stepped.lastSeq
-        val canVote  = stepped.votedFor.forall(_ == candidateId)
-        val granted  = upToDate && canVote
+        val canVote = stepped.votedFor.forall(_ == candidateId)
+        val granted = upToDate && canVote
         val next =
           if granted then
             stepped.copy(
@@ -185,22 +187,22 @@ final class ProtoConsensusEngine private (
     lastSeq: Long
   ): UIO[(Boolean, Long)] =
     for {
-      updated <- updateAndPersist { st =>
-                   if term < st.term then ((false, st.term), st)
-                   else
-                     val stepped =
-                       if term > st.term then st.copy(term = term, votedFor = None)
-                       else st
-                     val next = stepped.copy(
-                       role = Role.Follower,
-                       leaderId = Some(leaderId),
-                       lastHeartbeatNanos = java.lang.System.nanoTime(),
-                       lastSeq = lastSeq
-                     )
-                     ((true, next.term), next)
-                 }
+      updated                <- updateAndPersist { st =>
+                                  if term < st.term then ((false, st.term), st)
+                                  else
+                                    val stepped =
+                                      if term > st.term then st.copy(term = term, votedFor = None)
+                                      else st
+                                    val next = stepped.copy(
+                                      role = Role.Follower,
+                                      leaderId = Some(leaderId),
+                                      lastHeartbeatNanos = java.lang.System.nanoTime(),
+                                      lastSeq = lastSeq
+                                    )
+                                    ((true, next.term), next)
+                                }
       (accepted, currentTerm) = updated
-      _                    <- stateMachine.installSnapshot(snapshot).when(accepted)
+      _                      <- stateMachine.installSnapshot(snapshot).when(accepted)
     } yield (accepted, currentTerm)
 
   def spawnDrivers: UIO[Fiber.Runtime[Throwable, Nothing]] =
@@ -209,28 +211,28 @@ final class ProtoConsensusEngine private (
   private def replicate(term: Long, seq: Long, command: Array[Byte]): UIO[Unit] =
     peersRef.get.flatMap { peers =>
       ZIO.foreachParDiscard(peers) { case (peerId, client) =>
-      client
-        .appendEntries(
-          AppendEntriesRequest(
-            leaderId = nodeId,
-            term = term,
-            command = ByteString.copyFrom(command),
-            seq = seq
+        client
+          .appendEntries(
+            AppendEntriesRequest(
+              leaderId = nodeId,
+              term = term,
+              command = ByteString.copyFrom(command),
+              seq = seq
+            )
           )
-        )
-        .foldZIO(
-          _ => ZIO.unit,
-          resp =>
-            stepDownIfStale(resp.term) *>
-              // A follower whose lastSeq diverges from ours rejects with
-              // success=false; without a catch-up the strict seq check keeps
-              // refusing every subsequent entry until a new election. Push a
-              // snapshot to bring them in sync as long as we're still the
-              // leader at this term.
-              ZIO.when(!resp.success && resp.term <= term) {
-                sendSnapshotTo(peerId, client)
-              }
-        )
+          .foldZIO(
+            _ => ZIO.unit,
+            resp =>
+              stepDownIfStale(resp.term) *>
+                // A follower whose lastSeq diverges from ours rejects with
+                // success=false; without a catch-up the strict seq check keeps
+                // refusing every subsequent entry until a new election. Push a
+                // snapshot to bring them in sync as long as we're still the
+                // leader at this term.
+                ZIO.when(!resp.success && resp.term <= term) {
+                  sendSnapshotTo(peerId, client)
+                }
+          )
       }
     }
 
@@ -259,21 +261,21 @@ final class ProtoConsensusEngine private (
     for {
       currentRole <- role
       _           <- currentRole match {
-                       case Role.Leader              => sendHeartbeats
+                       case Role.Leader                    => sendHeartbeats
                        case Role.Follower | Role.Candidate =>
                          for {
-                           now <- Clock.nanoTime
-                           st  <- stateRef.get
-                           jitter <- Random.nextLongBetween(
-                                       0L,
-                                       math.max(1L, config.electionTimeout.toMillis / 2)
-                                     )
+                           now         <- Clock.nanoTime
+                           st          <- stateRef.get
+                           jitter      <- Random.nextLongBetween(
+                                            0L,
+                                            math.max(1L, config.electionTimeout.toMillis / 2)
+                                          )
                            timeoutNanos = config.electionTimeout.toNanos + (jitter * 1_000_000L)
                            elapsed      = now - st.lastHeartbeatNanos
                            _           <- startElection.when(elapsed >= timeoutNanos)
                          } yield ()
                      }
-      _ <- ZIO.sleep(config.heartbeatInterval)
+      _           <- ZIO.sleep(config.heartbeatInterval)
     } yield ()
 
   private def sendHeartbeats: UIO[Unit] =
@@ -292,50 +294,51 @@ final class ProtoConsensusEngine private (
 
   private def startElection: UIO[Unit] =
     for {
-      election <- updateAndPersist { st =>
-                    val next = st.copy(
-                      role = Role.Candidate,
-                      term = st.term + 1,
-                      votedFor = Some(nodeId),
-                      leaderId = None,
-                      lastHeartbeatNanos = java.lang.System.nanoTime()
-                    )
-                    ((next.term, next.lastSeq), next)
-                  }
+      election                   <- updateAndPersist { st =>
+                                      val next = st.copy(
+                                        role = Role.Candidate,
+                                        term = st.term + 1,
+                                        votedFor = Some(nodeId),
+                                        leaderId = None,
+                                        lastHeartbeatNanos = java.lang.System.nanoTime()
+                                      )
+                                      ((next.term, next.lastSeq), next)
+                                    }
       (term: Long, lastSeq: Long) = election
-      _              <- ZIO.logInfo(s"starting election on node $nodeId term $term")
-      peers          <- peersRef.get
-      responses      <- ZIO.foreachPar(peers.toList) { case (peerId, client) =>
-                          client
-                            .requestVote(VoteRequest(candidateId = nodeId, term = term, lastSeq = lastSeq))
-                            .map(Some(_))
-                            .catchAll { _ =>
-                              ZIO.logDebug(s"vote request failed for peer $peerId") *> ZIO.none
-                            }
-                        }
-      higherTerm = responses.flatten.collect { case resp if resp.term > term => resp.term }.headOption
-      _         <- higherTerm match {
-                     case Some(newTerm) =>
-                       updateAndPersist { st =>
-                         if newTerm > st.term then
-                           ((), st.copy(term = newTerm, role = Role.Follower, votedFor = None))
-                         else ((), st)
-                       }
-                     case None          =>
-                       val votes = 1 + responses.flatten.count(_.granted)
-                       val needed = (peers.size + 1) / 2 + 1
-                       if votes >= needed then
-                         stateRef.modify { st =>
-                           if st.role == Role.Candidate && st.term == term then
-                             val next = st.copy(role = Role.Leader, leaderId = Some(nodeId))
-                             (true, next)
-                           else (false, st)
-                         }.flatMap { elected =>
-                           ZIO.logInfo(s"node $nodeId elected leader term $term").when(elected) *>
-                             broadcastSnapshot.when(elected)
-                         }
-                       else ZIO.logInfo(s"node $nodeId lost election term $term votes $votes")
-                   }
+      _                          <- ZIO.logInfo(s"starting election on node $nodeId term $term")
+      peers                      <- peersRef.get
+      responses                  <- ZIO.foreachPar(peers.toList) { case (peerId, client) =>
+                                      client
+                                        .requestVote(VoteRequest(candidateId = nodeId, term = term, lastSeq = lastSeq))
+                                        .map(Some(_))
+                                        .catchAll { _ =>
+                                          ZIO.logDebug(s"vote request failed for peer $peerId") *> ZIO.none
+                                        }
+                                    }
+      higherTerm                  = responses.flatten.collect { case resp if resp.term > term => resp.term }.headOption
+      _                          <- higherTerm match {
+                                      case Some(newTerm) =>
+                                        updateAndPersist { st =>
+                                          if newTerm > st.term then ((), st.copy(term = newTerm, role = Role.Follower, votedFor = None))
+                                          else ((), st)
+                                        }
+                                      case None          =>
+                                        val votes = 1 + responses.flatten.count(_.granted)
+                                        val needed = (peers.size + 1) / 2 + 1
+                                        if votes >= needed then
+                                          stateRef
+                                            .modify { st =>
+                                              if st.role == Role.Candidate && st.term == term then
+                                                val next = st.copy(role = Role.Leader, leaderId = Some(nodeId))
+                                                (true, next)
+                                              else (false, st)
+                                            }
+                                            .flatMap { elected =>
+                                              ZIO.logInfo(s"node $nodeId elected leader term $term").when(elected) *>
+                                                broadcastSnapshot.when(elected)
+                                            }
+                                        else ZIO.logInfo(s"node $nodeId lost election term $term votes $votes")
+                                    }
     } yield ()
 
   private def broadcastSnapshot: UIO[Unit] =
@@ -361,10 +364,9 @@ final class ProtoConsensusEngine private (
                   }
     } yield ()
 
-  /** Step down to follower if an outgoing heartbeat / append / snapshot
-    * response carries a term greater than ours. Without this step a stale
-    * leader can stay convinced it is in charge while a follower has sprinted
-    * ahead (e.g. through repeated election timeouts during a partition).
+  /** Step down to follower if an outgoing heartbeat / append / snapshot response carries a term greater than ours.
+    * Without this step a stale leader can stay convinced it is in charge while a follower has sprinted ahead (e.g.
+    * through repeated election timeouts during a partition).
     */
   private def stepDownIfStale(observedTerm: Long): UIO[Unit] =
     updateAndPersist { st =>
@@ -384,50 +386,51 @@ final class ProtoConsensusEngine private (
 }
 
 object ProtoConsensusEngine {
+
   def make(
     nodeId: String,
     stateMachine: ProtoStateMachine,
     config: ProtoRaftConfig
   ): ZIO[Scope, Throwable, ProtoConsensusEngine] =
     for {
-      peerEntries <- ZIO.foreach(config.initialEndpoints.filter(_.id != nodeId)) { ep =>
-                       DRefConsensusClient
-                         .scoped(GrpcChannels.managedChannel(ep.address))
-                         .map(ep.id -> _)
-                     }
-      peers      = peerEntries.toMap
-      voterStore <- config.storageDir match {
-                      case Some(path) => VoterStateStore.file(path)
-                      case None       => ZIO.succeed(VoterStateStore.noop)
-                    }
-      loaded     <- voterStore.load
+      peerEntries    <- ZIO.foreach(config.initialEndpoints.filter(_.id != nodeId)) { ep =>
+                          DRefConsensusClient
+                            .scoped(GrpcChannels.managedChannel(ep.address))
+                            .map(ep.id -> _)
+                        }
+      peers           = peerEntries.toMap
+      voterStore     <- config.storageDir match {
+                          case Some(path) => VoterStateStore.file(path)
+                          case None       => ZIO.succeed(VoterStateStore.noop)
+                        }
+      loaded         <- voterStore.load
       // When persistent state already exists, never short-circuit to leader:
       // doing so would skip the election protocol and the persisted term/vote
       // would no longer match a fresh leader's claim. Let the standard
       // election path run and increment the term cleanly.
-      hasPersisted   = loaded.term > 0L || loaded.votedFor.isDefined
-      initialRole    = if peers.isEmpty && !hasPersisted then Role.Leader else Role.Follower
-      initialLeader  = if initialRole == Role.Leader then Some(nodeId) else None
-      initialTerm    = if initialRole == Role.Leader then 1L else loaded.term
+      hasPersisted    = loaded.term > 0L || loaded.votedFor.isDefined
+      initialRole     = if peers.isEmpty && !hasPersisted then Role.Leader else Role.Follower
+      initialLeader   = if initialRole == Role.Leader then Some(nodeId) else None
+      initialTerm     = if initialRole == Role.Leader then 1L else loaded.term
       initialVotedFor = if initialRole == Role.Leader then None else loaded.votedFor
-      stateRef      <- Ref.make(
-                         ConsensusState(
-                           role = initialRole,
-                           term = initialTerm,
-                           votedFor = initialVotedFor,
-                           leaderId = initialLeader,
-                           lastSeq = 0L,
-                           lastHeartbeatNanos = java.lang.System.nanoTime()
-                         )
-                       )
+      stateRef       <- Ref.make(
+                          ConsensusState(
+                            role = initialRole,
+                            term = initialTerm,
+                            votedFor = initialVotedFor,
+                            leaderId = initialLeader,
+                            lastSeq = 0L,
+                            lastHeartbeatNanos = java.lang.System.nanoTime()
+                          )
+                        )
       // If we took the single-node leader shortcut, fsync the bootstrap term
       // immediately so a crash before the first election still leaves us at
       // a term we can compare against on restart.
-      _ <- voterStore
-             .save(VoterState(initialTerm, initialVotedFor))
-             .when(initialTerm != loaded.term || initialVotedFor != loaded.votedFor)
-      persistMutex <- Semaphore.make(1)
-      peersRef     <- Ref.make(peers)
+      _              <- voterStore
+                          .save(VoterState(initialTerm, initialVotedFor))
+                          .when(initialTerm != loaded.term || initialVotedFor != loaded.votedFor)
+      persistMutex   <- Semaphore.make(1)
+      peersRef       <- Ref.make(peers)
     } yield new ProtoConsensusEngine(nodeId, stateMachine, peersRef, config, stateRef, voterStore, persistMutex)
 
   def waitForLeader(engine: ProtoConsensusEngine, max: Duration): UIO[Option[String]] =

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoDRefGrpcServer.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoDRefGrpcServer.scala
@@ -19,11 +19,11 @@ final class ProtoDRefGrpcServer(
             s"not-leader:${leaderId.getOrElse("unknown")}"
           )
         )
-      case ConsensusError.NoLeader =>
+      case ConsensusError.NoLeader            =>
         new StatusException(Status.FAILED_PRECONDITION.withDescription("no-leader:unknown"))
-      case ConsensusError.Serialize(message) =>
+      case ConsensusError.Serialize(message)  =>
         new StatusException(Status.INTERNAL.withDescription(s"serialize: $message"))
-      case ConsensusError.Transport(message) =>
+      case ConsensusError.Transport(message)  =>
         new StatusException(Status.UNAVAILABLE.withDescription(message))
     }
 
@@ -61,11 +61,14 @@ final class ProtoDRefGrpcServer(
       response <-
         if !isLeader then ZIO.fail(mapErr(ConsensusError.NotLeader(leaderId)))
         else
-          consensus.stateMachine.get(request.name).mapError { err =>
-            new StatusException(Status.INTERNAL.withDescription(err.getMessage))
-          }.map { value =>
-            GetElementResponse(value.map(com.google.protobuf.ByteString.copyFrom))
-          }
+          consensus.stateMachine
+            .get(request.name)
+            .mapError { err =>
+              new StatusException(Status.INTERNAL.withDescription(err.getMessage))
+            }
+            .map { value =>
+              GetElementResponse(value.map(com.google.protobuf.ByteString.copyFrom))
+            }
     } yield response
 
   override def deleteElement(

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoRaftDRefContext.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoRaftDRefContext.scala
@@ -20,7 +20,7 @@ trait ProtoRaftDRefContext extends DRefContext {
 
 object ProtoRaftDRefContext {
 
-  private final class ProtoDRefClient(
+  final private class ProtoDRefClient(
     ipClientsRef: Ref[Map[String, DRefRaftClient]],
     aliasRef: Ref[Map[String, DRefRaftClient]]
   ) {
@@ -104,44 +104,43 @@ object ProtoRaftDRefContext {
     leaderWait: Duration = 500.millis
   ): ZIO[Scope, Throwable, ProtoRaftDRefContext] =
     for {
-      ips         <- ipProvider.findNodeAddresses()
-      myIp        <- ipProvider.findMyAddress()
-      port         = config.port
-      bindAddress  = config.bindAddress.getOrElse(s"$myIp:$port")
-      endpoints    = ips.map(ip => NodeEndpoint(ip, s"$ip:$port"))
-      ctx         <- start(config.copy(bindAddress = Some(bindAddress), initialEndpoints = endpoints), leaderWait)
-      _           <- addressPollLoop(ipProvider, ctx, config.addressPollInterval).forkScoped
+      ips        <- ipProvider.findNodeAddresses()
+      myIp       <- ipProvider.findMyAddress()
+      port        = config.port
+      bindAddress = config.bindAddress.getOrElse(s"$myIp:$port")
+      endpoints   = ips.map(ip => NodeEndpoint(ip, s"$ip:$port"))
+      ctx        <- start(config.copy(bindAddress = Some(bindAddress), initialEndpoints = endpoints), leaderWait)
+      _          <- addressPollLoop(ipProvider, ctx, config.addressPollInterval).forkScoped
     } yield ctx
 
   def start(config: ProtoRaftConfig, leaderWait: Duration = 500.millis): ZIO[Scope, Throwable, ProtoRaftDRefContext] =
     for {
-      nodeId <- config.nodeId match {
-                  case Some(id) => ZIO.succeed(id)
-                  case None       => Random.nextLongBetween(0L, 99_999L).map(_.toString)
-                }
-      bindAddress = config.bindAddress.getOrElse(s"127.0.0.1:${config.port}")
+      nodeId         <- ZIO.fromOption(config.nodeId).orElse(Random.nextLongBetween(0L, 99_999L).map(_.toString))
+      bindAddress     = config.bindAddress.getOrElse(s"127.0.0.1:${config.port}")
       // IP-based discovery uses the IP itself as a placeholder endpoint id,
       // so our own address would otherwise stay in the peer list (whose
       // self-skip matches on nodeId) and inflate the quorum. Drop any
       // endpoint pointing at our bind, then add ourselves once under nodeId.
-      endpoints   = config.initialEndpoints.filterNot(_.address == bindAddress) :+
-                      NodeEndpoint(nodeId, bindAddress)
-      memberIds   = endpoints.map(_.id)
-      stateMachine <- ProtoStateMachine.make
-      resolvedConfig = config.copy(nodeId = Some(nodeId), initialEndpoints = endpoints)
-      consensus    <- ProtoConsensusEngine.make(nodeId, stateMachine, resolvedConfig)
-      drefServer    = new ProtoDRefGrpcServer(consensus, memberIds)
+      endpoints       = config.initialEndpoints.filterNot(_.address == bindAddress) :+
+                          NodeEndpoint(nodeId, bindAddress)
+      memberIds       = endpoints.map(_.id)
+      stateMachine   <- ProtoStateMachine.make
+      resolvedConfig  = config.copy(nodeId = Some(nodeId), initialEndpoints = endpoints)
+      consensus      <- ProtoConsensusEngine.make(nodeId, stateMachine, resolvedConfig)
+      drefServer      = new ProtoDRefGrpcServer(consensus, memberIds)
       consensusServer = new DRefConsensusGrpcServer(consensus)
-      builder       = ServerBuilder.forPort(config.port).addService(ProtoReflectionService.newInstance())
-      services      = ServiceList.add(drefServer).add(consensusServer)
-      _            <- ServerLayer.fromServiceList(builder, services).launch.forkScoped
-      _            <- waitForLocalGrpcServer(config.port)
-      clients      <- ZIO.foreach(endpoints) { ep =>
-                        DRefRaftClient
-                          .scoped(GrpcChannels.managedChannel(ep.address))
-                          .map(ep.id -> _)
-                      }.map(_.toMap)
-      clientsRef   <- Ref.make(clients)
+      builder         = ServerBuilder.forPort(config.port).addService(ProtoReflectionService.newInstance())
+      services        = ServiceList.add(drefServer).add(consensusServer)
+      _              <- ServerLayer.fromServiceList(builder, services).launch.forkScoped
+      _              <- waitForLocalGrpcServer(config.port)
+      clients        <- ZIO
+                          .foreach(endpoints) { ep =>
+                            DRefRaftClient
+                              .scoped(GrpcChannels.managedChannel(ep.address))
+                              .map(ep.id -> _)
+                          }
+                          .map(_.toMap)
+      clientsRef     <- Ref.make(clients)
       // IP-based discovery keys peers by IP, but consensus identifies them by
       // real nodeId (heartbeats carry leader_id = randomly-chosen string).
       // Probe each peer's GetEndpoints — by convention the last entry in the
@@ -152,15 +151,15 @@ object ProtoRaftDRefContext {
       // gRPC when we probe them, and one-shot discovery would leave the alias
       // permanently missing. Periodic refresh also covers rolling restarts
       // that hand a peer a new random nodeId.
-      aliasRef     <- Ref.make(Map.empty[String, DRefRaftClient])
-      _            <- refreshAliases(clientsRef, nodeId, aliasRef)
-      _            <- refreshAliases(clientsRef, nodeId, aliasRef)
-                        .repeat(Schedule.spaced(1.second))
-                        .forkScoped
-      client         = new ProtoDRefClient(clientsRef, aliasRef)
-      _            <- consensus.spawnDrivers
-      _            <- ttlReaper(consensus).forkScoped
-      _            <- ProtoConsensusEngine.waitForLeader(consensus, leaderWait)
+      aliasRef       <- Ref.make(Map.empty[String, DRefRaftClient])
+      _              <- refreshAliases(clientsRef, nodeId, aliasRef)
+      _              <- refreshAliases(clientsRef, nodeId, aliasRef)
+                          .repeat(Schedule.spaced(1.second))
+                          .forkScoped
+      client          = new ProtoDRefClient(clientsRef, aliasRef)
+      _              <- consensus.spawnDrivers
+      _              <- ttlReaper(consensus).forkScoped
+      _              <- ProtoConsensusEngine.waitForLeader(consensus, leaderWait)
     } yield new Impl(nodeId, resolvedConfig, consensus, stateMachine, client, clientsRef, aliasRef, memberIds)
 
   private def addressPollLoop(
@@ -171,15 +170,15 @@ object ProtoRaftDRefContext {
     val impl = ctx.asInstanceOf[Impl]
     val poll =
       for {
-        ips           <- ipProvider.findNodeAddresses()
-        port           = impl.config.port
-        bindAddress    = impl.config.bindAddress.getOrElse(s"127.0.0.1:$port")
-        endpoints      = ips.map(ip => NodeEndpoint(ip, s"$ip:$port"))
-        peerEndpoints  = endpoints.filterNot(_.address == bindAddress)
-        allEndpoints   = peerEndpoints :+ NodeEndpoint(impl.nodeId, bindAddress)
-        _             <- impl.consensus.syncPeers(peerEndpoints, impl.nodeId, bindAddress)
-        _             <- syncRaftClients(impl.clientsRef, allEndpoints)
-        _             <- refreshAliases(impl.clientsRef, impl.nodeId, impl.aliasRef)
+        ips          <- ipProvider.findNodeAddresses()
+        port          = impl.config.port
+        bindAddress   = impl.config.bindAddress.getOrElse(s"127.0.0.1:$port")
+        endpoints     = ips.map(ip => NodeEndpoint(ip, s"$ip:$port"))
+        peerEndpoints = endpoints.filterNot(_.address == bindAddress)
+        allEndpoints  = peerEndpoints :+ NodeEndpoint(impl.nodeId, bindAddress)
+        _            <- impl.consensus.syncPeers(peerEndpoints, impl.nodeId, bindAddress)
+        _            <- syncRaftClients(impl.clientsRef, allEndpoints)
+        _            <- refreshAliases(impl.clientsRef, impl.nodeId, impl.aliasRef)
       } yield ()
     poll.catchAll(_ => ZIO.unit).repeat(Schedule.spaced(interval)).unit
 
@@ -198,7 +197,7 @@ object ProtoRaftDRefContext {
                      .scoped(GrpcChannels.managedChannel(ep.address))
                      .map(ep.id -> _)
                  }
-      _ <- clientsRef.update(_ ++ added.toMap).when(added.nonEmpty)
+      _       <- clientsRef.update(_ ++ added.toMap).when(added.nonEmpty)
     } yield ()
 
   private def refreshAliases(
@@ -209,19 +208,19 @@ object ProtoRaftDRefContext {
     ipClientsRef.get.flatMap { ipClients =>
       ZIO
         .foreach(ipClients.toList) { case (id, raftClient) =>
-        if id == selfNodeId then ZIO.succeed(None)
-        else
-          raftClient
-            .getEndpoints(GetEndpointsRequest())
-            .either
-            .map {
-              case Right(resp) if resp.ids.nonEmpty =>
-                val realId = resp.ids.last
-                if realId != id && realId != selfNodeId then Some(realId -> raftClient)
-                else None
-              case _ => None
-            }
-      }
+          if id == selfNodeId then ZIO.succeed(None)
+          else
+            raftClient
+              .getEndpoints(GetEndpointsRequest())
+              .either
+              .map {
+                case Right(resp) if resp.ids.nonEmpty =>
+                  val realId = resp.ids.last
+                  if realId != id && realId != selfNodeId then Some(realId -> raftClient)
+                  else None
+                case _                                => None
+              }
+        }
         .flatMap { pairs =>
           val discovered = pairs.flatten.toMap
           // Merge rather than replace so a transient unreachable peer doesn't
@@ -230,7 +229,7 @@ object ProtoRaftDRefContext {
         }
     }
 
-  private final class Impl(
+  final private class Impl(
     override val nodeId: String,
     val config: ProtoRaftConfig,
     val consensus: ProtoConsensusEngine,
@@ -312,7 +311,7 @@ object ProtoRaftDRefContext {
         for {
           expireAt <- ttlToExpireAt(ttl)
           result   <- currentLeader.either.flatMap {
-                        case Left(_) =>
+                        case Left(_)       =>
                           // Membership changes (add/remove) can leave the cluster
                           // leaderless for several seconds while peers refresh and
                           // an election completes — retry like NotLeader.
@@ -320,11 +319,11 @@ object ProtoRaftDRefContext {
                         case Right(leader) =>
                           op(leader, expireAt).foldZIO(
                             {
-                              case ClientError.NotLeader(_) =>
+                              case ClientError.NotLeader(_)                           =>
                                 ZIO.sleep(30.millis) *> loop(0, 0)
                               case ClientError.Transport(_) if transportAttempts < 40 =>
                                 ZIO.sleep(50.millis) *> loop(transportAttempts + 1, unknownAttempts)
-                              case ClientError.Transport(msg) =>
+                              case ClientError.Transport(msg)                         =>
                                 ZIO.fail(new RuntimeException(s"transport error talking to leader: $msg"))
                               // Followers learn the leader's random nodeId via
                               // heartbeats before the alias-refresh fiber maps
@@ -333,9 +332,9 @@ object ProtoRaftDRefContext {
                               // the caller with a transient routing miss.
                               case ClientError.UnknownNode(_) if unknownAttempts < 20 =>
                                 ZIO.sleep(100.millis) *> loop(transportAttempts, unknownAttempts + 1)
-                              case ClientError.UnknownNode(target) =>
+                              case ClientError.UnknownNode(target)                    =>
                                 ZIO.fail(new RuntimeException(s"unknown node id $target"))
-                              case ClientError.Other(msg) =>
+                              case ClientError.Other(msg)                             =>
                                 ZIO.fail(new RuntimeException(msg))
                             },
                             ZIO.succeed(_)
@@ -356,10 +355,9 @@ object ProtoRaftDRefContext {
       consensus.leaderId.flatMap {
         case Some(id) => ZIO.succeed(id)
         case None     =>
-          ProtoConsensusEngine.waitForLeader(consensus, 1.second).flatMap {
-            case Some(id) => ZIO.succeed(id)
-            case None       => ZIO.fail(new RuntimeException("no leader elected"))
-          }
+          ProtoConsensusEngine
+            .waitForLeader(consensus, 1.second)
+            .flatMap(ZIO.fromOption(_).orElseFail(new RuntimeException("no leader elected")))
       }
   }
 

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoStateMachine.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoStateMachine.scala
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters.*
 
 sealed trait ApplyResult
+
 object ApplyResult {
   case object Unit extends ApplyResult
   final case class Created(created: Boolean) extends ApplyResult
@@ -31,10 +32,11 @@ final class ProtoStateMachine private (changesHub: Hub[ChangeEvent]) {
 
       case StateCommand.Op.SetElementIfNotExist(SetElementIfNotExistCommand(name, value, expireAt, _)) =>
         if innerMap.containsKey(name) then ZIO.succeed(ApplyResult.Created(false))
-        else
+        else {
           val bytes = value.toByteArray
           innerMap.put(name, ExpiringValue(bytes, expireAt))
           changesHub.publish(SetElement(name, bytes)).as(ApplyResult.Created(true))
+        }
 
       case StateCommand.Op.DeleteElement(DeleteElementCommand(name, _)) =>
         innerMap.remove(name)
@@ -93,6 +95,7 @@ final class ProtoStateMachine private (changesHub: Hub[ChangeEvent]) {
 }
 
 object ProtoStateMachine {
+
   def make: ZIO[Any, Nothing, ProtoStateMachine] =
     Hub.bounded[ChangeEvent](256).map(new ProtoStateMachine(_))
 }

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/StateCommands.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/StateCommands.scala
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString
 import io.github.tobia80.state_command.*
 
 object StateCommands {
+
   def setElement(name: String, value: Array[Byte], expireAt: Option[Long]): StateCommand =
     StateCommand(
       StateCommand.Op.SetElement(

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/VoterStateStore.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/VoterStateStore.scala
@@ -14,9 +14,8 @@ object VoterState {
 
 /** Persists Raft voter state (currentTerm, votedFor) across restarts.
   *
-  * Without this, a restarted node can grant a second vote in the same term and
-  * cause a split-brain — the one Raft safety invariant that *requires* stable
-  * storage even before any log persistence work.
+  * Without this, a restarted node can grant a second vote in the same term and cause a split-brain — the one Raft
+  * safety invariant that *requires* stable storage even before any log persistence work.
   */
 trait VoterStateStore {
   def load: Task[VoterState]
@@ -24,18 +23,17 @@ trait VoterStateStore {
 }
 
 object VoterStateStore {
-  private val Magic: Int    = 0x44524654 // "DRFT"
+  private val Magic: Int = 0x44524654 // "DRFT"
   private val Version: Byte = 1
-  private val FileName      = "voter-state"
-  private val TmpSuffix     = ".tmp"
+  private val FileName = "voter-state"
+  private val TmpSuffix = ".tmp"
 
-  /** In-memory no-op store. Returns empty state and discards writes — used
-    * when no `storageDir` is configured, preserving the previous in-memory
-    * behavior bit-for-bit.
+  /** In-memory no-op store. Returns empty state and discards writes — used when no `storageDir` is configured,
+    * preserving the previous in-memory behavior bit-for-bit.
     */
   val noop: VoterStateStore = new VoterStateStore {
-    def load: Task[VoterState]                 = ZIO.succeed(VoterState.empty)
-    def save(state: VoterState): Task[Unit]    = ZIO.unit
+    def load: Task[VoterState] = ZIO.succeed(VoterState.empty)
+    def save(state: VoterState): Task[Unit] = ZIO.unit
   }
 
   def file(dir: Path): Task[VoterStateStore] =
@@ -43,9 +41,9 @@ object VoterStateStore {
       .attemptBlocking(Files.createDirectories(dir))
       .as(new FileStore(dir))
 
-  private final class FileStore(dir: Path) extends VoterStateStore {
+  final private class FileStore(dir: Path) extends VoterStateStore {
     private val target = dir.resolve(FileName)
-    private val tmp    = dir.resolve(FileName + TmpSuffix)
+    private val tmp = dir.resolve(FileName + TmpSuffix)
 
     def load: Task[VoterState] =
       ZIO.attemptBlocking {
@@ -79,7 +77,7 @@ object VoterStateStore {
     val version = in.readByte()
     if version != Version then throw new IOException(s"voter-state version $version not supported")
     val term = in.readLong()
-    val len  = in.readInt()
+    val len = in.readInt()
     val votedFor =
       if len < 0 then None
       else {

--- a/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisClient.scala
+++ b/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisClient.scala
@@ -7,8 +7,7 @@ import io.lettuce.core.codec.ByteArrayCodec
 import io.lettuce.core.pubsub.api.reactive.RedisPubSubReactiveCommands
 import reactor.core.publisher.Mono
 import zio.stream.ZStream
-import zio.{Chunk, Scope, Task, ZIO}
-import zio.*
+import zio.{Chunk, Duration, Scope, Task, UIO, ZIO}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -38,18 +37,17 @@ object RedisClient {
     }
 
   def make(config: RedisConfig): ZIO[Scope, Throwable, RedisClient] =
-    ZIO.acquireRelease(ZIO.attempt(config.toClientResources))(res =>
-      awaitNettyFuture(res.shutdown())
-    ).flatMap { resources =>
-      ZIO.acquireRelease {
-        ZIO.attempt {
-          val client: core.RedisClient = core.RedisClient.create(resources, config.toRedisURI)
-          client.setOptions(config.toOptions)
-          val asyncClient = client.connect(ByteArrayCodec.INSTANCE).async
-          val reactive = client.connectPubSub(ByteArrayCodec.INSTANCE).reactive()
-          LettuceRedisClient(client, asyncClient, reactive)
-        }
-      }(client => client.close().ignore)
+    ZIO.acquireRelease(ZIO.attempt(config.toClientResources))(res => awaitNettyFuture(res.shutdown())).flatMap {
+      resources =>
+        ZIO.acquireRelease {
+          ZIO.attempt {
+            val client: core.RedisClient = core.RedisClient.create(resources, config.toRedisURI)
+            client.setOptions(config.toOptions)
+            val asyncClient = client.connect(ByteArrayCodec.INSTANCE).async
+            val reactive = client.connectPubSub(ByteArrayCodec.INSTANCE).reactive()
+            LettuceRedisClient(client, asyncClient, reactive)
+          }
+        }(client => client.close().ignore)
     }
 }
 
@@ -75,14 +73,15 @@ class LettuceRedisClient(
     ttl match {
       case Some(duration) =>
         val setArgs = SetArgs.Builder.nx.ex(duration.getSeconds)
-        ZIO.fromCompletionStage(async.set(name.toArray, value.toArray, setArgs)).map(res => res != null)
-      case None           => ZIO.fromCompletionStage(async.setnx(name.toArray, value.toArray)).map(res => res.booleanValue())
+        ZIO.fromCompletionStage(async.set(name.toArray, value.toArray, setArgs)).map(_ != null)
+      case None           => ZIO.fromCompletionStage(async.setnx(name.toArray, value.toArray)).map(_.booleanValue())
     }
 
   override def get(name: Chunk[Byte]): Task[Option[Chunk[Byte]]] =
     ZIO.fromCompletionStage(async.get(name.toArray)).map(Option(_).map(Chunk.fromArray))
 
-  override def del(name: Chunk[Byte]): Task[Long] = ZIO.fromCompletionStage(async.del(name.toArray)).map(_.longValue())
+  override def del(name: Chunk[Byte]): Task[Long] =
+    ZIO.fromCompletionStage(async.del(name.toArray)).map(_.longValue())
 
   override def expire(name: Chunk[Byte], ttl: Duration): Task[Boolean] =
     ZIO.fromCompletionStage(async.expire(name.toArray, ttl.toSeconds)).map(_.booleanValue())

--- a/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisDRefContext.scala
+++ b/dref-redis/src/main/scala/io/github/tobia80/dref/redis/RedisDRefContext.scala
@@ -70,13 +70,15 @@ case class RedisConfig(
   }
 
   def toOptions: ClientOptions = {
-    val socketOpts = SocketOptions.builder()
+    val socketOpts = SocketOptions
+      .builder()
       .connectTimeout(java.time.Duration.ofMillis(socket.connectTimeout.toMillis))
       .keepAlive(socket.keepAlive)
       .tcpNoDelay(socket.tcpNoDelay)
       .build()
 
-    val clientBuilder = ClientOptions.builder()
+    val clientBuilder = ClientOptions
+      .builder()
       .autoReconnect(autoReconnect)
       .disconnectedBehavior(disconnectedBehavior match
         case DisconnectedBehavior.Default        => ClientOptions.DisconnectedBehavior.DEFAULT
@@ -89,7 +91,8 @@ case class RedisConfig(
 
     commandTimeout.foreach { t =>
       clientBuilder.timeoutOptions(
-        TimeoutOptions.builder()
+        TimeoutOptions
+          .builder()
           .fixedTimeout(java.time.Duration.ofMillis(t.toMillis))
           .build()
       )
@@ -174,7 +177,6 @@ object RedisDRefContext {
         } yield ()
       }
 
-      import zio.Duration
       override def keepAliveStream(name: String, ttl: Duration): ZStream[Any, Throwable, Unit] = {
         val ttlZio = Duration.fromScala(ttl.asFiniteDuration / 1.25)
         ZStream.repeatZIOWithSchedule(expire(name, ttl), Schedule.fixed(ttlZio))
@@ -207,21 +209,22 @@ object RedisDRefContext {
       override def detectDeletionFromUnderlyingStream(
         name: String
       ): ZStream[Any, Throwable, DeleteElement] = {
-        val notExist = for {
-          result <- redisClient.get(Chunk.fromArray(name.getBytes))
-        } yield result.isEmpty
-        ZStream.repeatZIO(notExist.delay(1.second)).filter(identity).as(DeleteElement(name))
+        val notExist =
+          redisClient.get(Chunk.fromArray(name.getBytes)).map(_.isEmpty).delay(1.second)
+        ZStream.repeatZIO(notExist).filter(identity).as(DeleteElement(name))
       }
 
       override def detectStolenElement(name: String, value: Array[Byte]): ZStream[Any, Throwable, StolenElement] = {
-        val stolen = for {
-          result <- redisClient.get(Chunk.fromArray(name.getBytes))
-        } yield result match {
-          case None                                       => true
-          case Some(current) if !util.Arrays.equals(current.toArray, value) => true
-          case _                                          => false
-        }
-        ZStream.repeatZIO(stolen.delay(1.second)).filter(identity).as(StolenElement(name))
+        val stolen =
+          redisClient
+            .get(Chunk.fromArray(name.getBytes))
+            .map {
+              case None                                                         => true
+              case Some(current) if !util.Arrays.equals(current.toArray, value) => true
+              case _                                                            => false
+            }
+            .delay(1.second)
+        ZStream.repeatZIO(stolen).filter(identity).as(StolenElement(name))
       }
     }
   )

--- a/example/src/main/scala/io/tobia80/dref/Main.scala
+++ b/example/src/main/scala/io/tobia80/dref/Main.scala
@@ -21,7 +21,7 @@ object Main extends ZIOAppDefault {
   private val NodesAddresses = "DREF_NODE_ADDRESSES"
   private val NodesServices = "DREF_NODE_SERVICES"
   private val PortEnvironment = "DREF_PORT"
-  private val K8sService   = "DREF_K8S_SERVICE"
+  private val K8sService = "DREF_K8S_SERVICE"
   private val K8sNamespace = "DREF_K8S_NAMESPACE"
 
   private val ipProviderLayer: ZLayer[Any, Throwable, IpProvider] = {
@@ -85,9 +85,10 @@ object Main extends ZIOAppDefault {
         _    <- ZIO.service[DRefContext]
         _    <- Console.print("Please enter your name: ")
         name <- Console.readLine
-        _    <- Console.printLine(
-                  s"Hello, $name! Every message you type will be echoed back to you and to all subscribers. Type 'exit' to quit."
-                )
+        _    <-
+          Console.printLine(
+            s"Hello, $name! Every message you type will be echoed back to you and to all subscribers. Type 'exit' to quit."
+          )
         _    <- printReadMessageAndSend(name)
       } yield ()
 


### PR DESCRIPTION
## Summary

- Refactors core lock/read paths to use `foldCauseZIO`, `ZIO.fromOption`, and tighter `modifyZIO` composition in `DRef.scala`.
- Routes blocking network and filesystem work through `ZIO.attemptBlocking` in `IpProvider`, `KubernetesIpProvider`, and `VoterStateStore`.
- Simplifies Redis polling streams and tightens explicit ZIO imports in the Redis client layer.
- Includes a follow-up scalafmt pass on raft proto modules and the example app.

## Test plan

- [x] `sbt dref-core/test dref-raft/test`
- [ ] `sbt dref-redis/test` (requires Redis on localhost:6379)
- [ ] `sbt scalafmtCheck`


Made with [Cursor](https://cursor.com)