### PR TITLE
Add PostgreSQL-backed Raft persistence for ephemeral K8s deployments

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -28,6 +28,18 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: dref_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d dref_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +52,10 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
       - name: Run tests
+        env:
+          DREF_TEST_POSTGRES_JDBC_URL: jdbc:postgresql://localhost:5432/dref_test
+          DREF_TEST_POSTGRES_USER: postgres
+          DREF_TEST_POSTGRES_PASSWORD: test
         run: sbt test
 
   rust:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ redis-cli ping  # should return PONG
 
 | Scope | Command | External deps |
 |-------|---------|---------------|
-| Scala – all | `sbt test` | Redis on localhost:6379 |
+| Scala – all | `sbt test` | Redis on localhost:6379; PostgreSQL on localhost:5432 (`dref_test` DB) for Raft postgres storage tests |
 | Scala – core + raft only | `sbt dref-core/test dref-raft/test` | None |
 | Rust – core + raft | `cd rust && cargo test -p dref-core -p dref-raft` | None |
 | Rust – redis | `cd rust && cargo test -p dref-redis --features test-redis` | Redis on localhost:6379 |

--- a/README.md
+++ b/README.md
@@ -205,15 +205,20 @@ twice in the same term. It also snapshots the state machine to the same storage
 directory and restores both the key/value contents and the last applied
 consensus sequence on restart.
 
-DRef is restart-safe as long as each node is configured with a stable
-`storageDir`.
+DRef is restart-safe when each node has durable storage. You can use either a
+local directory (`storageDir`) or PostgreSQL (`postgres`).
 
 ```scala
 ProtoRaftConfig(
   port = 8082,
-  // Required for any multi-node cluster that needs to survive restarts.
-  // Point this at a stable per-node volume (PersistentVolumeClaim on K8s).
+  // Option A — local disk (typical with a per-pod PersistentVolumeClaim).
   storageDir = Some(java.nio.file.Paths.get("/var/lib/dref/node-1")),
+  // Option B — shared PostgreSQL (works with ephemeral pods / Deployments).
+  // postgres = Some(RaftPostgresConfig(
+  //   jdbcUrl = "jdbc:postgresql://postgres:5432/dref",
+  //   user = Some("dref"),
+  //   password = Some("secret"),
+  // )),
   // Persist a state-machine snapshot after every N applied commands.
   // Set to 0 to disable automatic snapshots.
   snapshotEvery = 1000,
@@ -221,12 +226,16 @@ ProtoRaftConfig(
 )
 ```
 
-If `storageDir` is `None` (the default), the node keeps voter state and
-snapshots in memory only. That is fine for single-process tests but unsafe for
-multi-node clusters: a node that restarts without persistent `votedFor` can
-grant a second vote in the same term, and a node that restarts without a
-snapshot must be reseeded by the leader. Deploy multi-node Raft clusters with a
-per-node PersistentVolumeClaim (or equivalent) rather than a plain `Deployment`.
+When `postgres` is set it takes precedence over `storageDir`. Each node writes
+its voter state and snapshots under its stable `nodeId`, so a multi-node cluster
+can run as a Kubernetes `Deployment` (no StatefulSet or per-pod volume) as long
+as every replica has a distinct `nodeId` and points at the same database.
+
+If both `storageDir` and `postgres` are unset (the default), the node keeps
+voter state and snapshots in memory only. That is fine for single-process tests
+but unsafe for multi-node clusters: a node that restarts without persistent
+`votedFor` can grant a second vote in the same term, and a node that restarts
+without a snapshot must be reseeded by the leader.
 
 Snapshots are full state-machine images, not durable Raft log segments. The
 current consensus engine uses monotonic sequence numbers and `InstallSnapshot`

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ val raftDeps = Seq(
   "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-core" % "0.6.3",
   "org.apache.commons"             % "commons-lang3" % "3.20.0",
   "io.projectreactor"              % "reactor-core"  % "3.8.5",
+  "org.postgresql"                 % "postgresql"    % "42.7.7",
 
   // grpc
   "io.grpc"               % "grpc-netty"           % "1.81.0",

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
@@ -92,8 +92,8 @@ final class ProtoConsensusEngine private (
       } yield result
     }
 
-  /** Record that a command was successfully applied. When the running tally crosses the configured
-    * `snapshotEvery` threshold, fork off a snapshot write so the on-disk picture catches up.
+  /** Record that a command was successfully applied. When the running tally crosses the configured `snapshotEvery`
+    * threshold, fork off a snapshot write so the on-disk picture catches up.
     *
     * The write is forked rather than awaited: snapshotting is a *durability* optimisation, not a correctness
     * requirement, so a slow disk must not stretch out replication latency. If the write fails we log and reset the
@@ -102,17 +102,22 @@ final class ProtoConsensusEngine private (
   private def noteApplied: UIO[Unit] =
     if config.snapshotEvery <= 0 then ZIO.unit
     else
-      appliesSinceSnapshot.modify { n =>
-        val next = n + 1L
-        if next >= config.snapshotEvery.toLong then (true, 0L) else (false, next)
-      }.flatMap { shouldSnapshot =>
-        ZIO.when(shouldSnapshot)(persistSnapshotInBackground).unit
-      }
+      appliesSinceSnapshot
+        .modify { n =>
+          val next = n + 1L
+          if next >= config.snapshotEvery.toLong then (true, 0L) else (false, next)
+        }
+        .flatMap { shouldSnapshot =>
+          ZIO.when(shouldSnapshot)(persistSnapshotInBackground).unit
+        }
 
   private def persistSnapshotInBackground: UIO[Unit] =
-    persistSnapshotNow.catchAll { t =>
-      ZIO.logWarningCause(s"state-machine snapshot save failed on node $nodeId", Cause.fail(t))
-    }.forkDaemon.unit
+    persistSnapshotNow
+      .catchAll { t =>
+        ZIO.logWarningCause(s"state-machine snapshot save failed on node $nodeId", Cause.fail(t))
+      }
+      .forkDaemon
+      .unit
 
   /** Take a snapshot of the state machine and fsync it to disk. Serialised so concurrent triggers don't both write —
     * the second waits for the first, then takes a fresh snapshot itself.
@@ -212,19 +217,19 @@ final class ProtoConsensusEngine private (
   /** Handle a PreVote request (Ongaro thesis §9.6).
     *
     * PreVote is a "would-you-vote-for-me" probe a candidate runs BEFORE it actually bumps its term. The voter:
-    *   1. does NOT change its own `term` / `votedFor` — granting a PreVote is hypothetical, so there is nothing to fsync;
-    *   2. refuses if it has heard from a leader within the election timeout — that is the disruption guard PreVote
-    *      exists for, since a partitioned node that kept incrementing its term in isolation must not be able to force
-    *      a real election on rejoin;
-    *   3. otherwise grants iff `lastSeq` is at least as up-to-date as ours AND the proposed term strictly beats ours.
+    *   1. does NOT change its own `term` / `votedFor` — granting a PreVote is hypothetical, so there is nothing to
+    *      fsync; 2. refuses if it has heard from a leader within the election timeout — that is the disruption guard
+    *      PreVote exists for, since a partitioned node that kept incrementing its term in isolation must not be able to
+    *      force a real election on rejoin; 3. otherwise grants iff `lastSeq` is at least as up-to-date as ours AND the
+    *      proposed term strictly beats ours.
     *
     * The returned term is always our current term — the voter never adopts the candidate's hypothetical term.
     */
   def handlePreVote(candidateId: String, term: Long, lastSeq: Long): UIO[(Boolean, Long)] =
     for {
-      now      <- ZIO.succeed(java.lang.System.nanoTime())
-      st       <- stateRef.get
-      response  =
+      now     <- ZIO.succeed(java.lang.System.nanoTime())
+      st      <- stateRef.get
+      response =
         if term <= st.term then (false, st.term)
         else
           // A node still in the Leader role refuses pre-votes outright — granting one would amount to volunteering
@@ -232,9 +237,9 @@ final class ProtoConsensusEngine private (
           // AppendEntries/Heartbeat response; until that signal arrives it trusts its own role. For followers, the
           // recency check on the last heartbeat plays the equivalent role: if we've heard from a leader within the
           // election timeout, the cluster is healthy and we shouldn't help an isolated candidate disrupt it.
-          val elapsedNanos    = now - st.lastHeartbeatNanos
-          val leaderRecent    = st.leaderId.isDefined && elapsedNanos < config.electionTimeout.toNanos
-          val isActiveLeader  = st.role == Role.Leader
+          val elapsedNanos = now - st.lastHeartbeatNanos
+          val leaderRecent = st.leaderId.isDefined && elapsedNanos < config.electionTimeout.toNanos
+          val isActiveLeader = st.role == Role.Leader
           if isActiveLeader || leaderRecent then (false, st.term)
           else
             val upToDate = lastSeq >= st.lastSeq
@@ -388,41 +393,41 @@ final class ProtoConsensusEngine private (
     */
   private def runPreVote: UIO[Boolean] =
     for {
-      st            <- stateRef.get
-      currentTerm    = st.term
-      proposedTerm   = currentTerm + 1
-      lastSeq        = st.lastSeq
-      peers         <- peersRef.get
-      clusterSize    = peers.size + 1
-      needed         = clusterSize / 2 + 1
-      responses     <- ZIO.foreachPar(peers.toList) { case (peerId, client) =>
-                         client
-                           .requestPreVote(
-                             PreVoteRequest(candidateId = nodeId, term = proposedTerm, lastSeq = lastSeq)
-                           )
-                           .map(Some(_))
-                           .catchAll { _ =>
-                             ZIO.logDebug(s"pre-vote request failed for peer $peerId") *> ZIO.none
-                           }
-                       }
-      higherTerm     = responses.flatten.collect { case resp if resp.term > currentTerm => resp.term }.headOption
-      result        <- higherTerm match {
-                         case Some(newTerm) => stepDownIfStale(newTerm).as(false)
-                         case None          =>
-                           val grants = 1 + responses.flatten.count(_.granted)
-                           ZIO.succeed(grants >= needed)
-                       }
+      st          <- stateRef.get
+      currentTerm  = st.term
+      proposedTerm = currentTerm + 1
+      lastSeq      = st.lastSeq
+      peers       <- peersRef.get
+      clusterSize  = peers.size + 1
+      needed       = clusterSize / 2 + 1
+      responses   <- ZIO.foreachPar(peers.toList) { case (peerId, client) =>
+                       client
+                         .requestPreVote(
+                           PreVoteRequest(candidateId = nodeId, term = proposedTerm, lastSeq = lastSeq)
+                         )
+                         .map(Some(_))
+                         .catchAll { _ =>
+                           ZIO.logDebug(s"pre-vote request failed for peer $peerId") *> ZIO.none
+                         }
+                     }
+      higherTerm   = responses.flatten.collect { case resp if resp.term > currentTerm => resp.term }.headOption
+      result      <- higherTerm match {
+                       case Some(newTerm) => stepDownIfStale(newTerm).as(false)
+                       case None          =>
+                         val grants = 1 + responses.flatten.count(_.granted)
+                         ZIO.succeed(grants >= needed)
+                     }
     } yield result
 
   private def startElection: UIO[Unit] =
     for {
-      passed                     <- runPreVote
-      _                          <- if !passed then
-                                      // Refresh the heartbeat clock so we don't immediately spin into another
-                                      // pre-vote attempt on the next tick — the guard would just reject us again.
-                                      stateRef.update(_.copy(lastHeartbeatNanos = java.lang.System.nanoTime())) *>
-                                        ZIO.logDebug(s"pre-vote failed on node $nodeId; staying follower")
-                                    else realElection
+      passed <- runPreVote
+      _      <- if !passed then
+                  // Refresh the heartbeat clock so we don't immediately spin into another
+                  // pre-vote attempt on the next tick — the guard would just reject us again.
+                  stateRef.update(_.copy(lastHeartbeatNanos = java.lang.System.nanoTime())) *>
+                    ZIO.logDebug(s"pre-vote failed on node $nodeId; staying follower")
+                else realElection
     } yield ()
 
   private def realElection: UIO[Unit] =
@@ -532,13 +537,21 @@ object ProtoConsensusEngine {
                             .map(ep.id -> _)
                         }
       peers           = peerEntries.toMap
-      voterStore     <- config.storageDir match {
-                          case Some(path) => VoterStateStore.file(path)
-                          case None       => ZIO.succeed(VoterStateStore.noop)
+      voterStore     <- config.postgres match {
+                          case Some(pg) => RaftPostgresStorage.voterStateStore(pg, nodeId)
+                          case None     =>
+                            config.storageDir match {
+                              case Some(path) => VoterStateStore.file(path)
+                              case None       => ZIO.succeed(VoterStateStore.noop)
+                            }
                         }
-      snapshotStore  <- config.storageDir match {
-                          case Some(path) => StateMachineSnapshotStore.file(path)
-                          case None       => ZIO.succeed(StateMachineSnapshotStore.noop)
+      snapshotStore  <- config.postgres match {
+                          case Some(pg) => RaftPostgresStorage.snapshotStore(pg, nodeId)
+                          case None     =>
+                            config.storageDir match {
+                              case Some(path) => StateMachineSnapshotStore.file(path)
+                              case None       => ZIO.succeed(StateMachineSnapshotStore.noop)
+                            }
                         }
       // Hydrate the state machine BEFORE peers come online so we don't serve
       // empty reads or accept appends against a stale lastSeq baseline. If the

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoRaftConfig.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoRaftConfig.scala
@@ -20,8 +20,12 @@ case class ProtoRaftConfig(
   // forgets its vote across restarts, which can violate Raft safety in
   // multi-node setups; set this for any cluster that needs to survive restarts.
   storageDir: Option[Path] = None,
+  // Optional PostgreSQL persistence (one row per nodeId). Prefer this over
+  // `storageDir` when running on ephemeral pods (e.g. a K8s Deployment) so
+  // each replica can restart without a per-pod PersistentVolumeClaim.
+  postgres: Option[RaftPostgresConfig] = None,
   // How many applied commands between automatic state-machine snapshot writes.
-  // Only takes effect when `storageDir` is set. Lower = less restart catch-up
+  // Only takes effect when `storageDir` or `postgres` is set. Lower = less restart catch-up
   // traffic at the cost of more disk I/O. The default is conservative; bump it
   // for write-heavy clusters where each snapshot would still be cheap to
   // rebuild from the leader.

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/RaftPostgresConfig.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/RaftPostgresConfig.scala
@@ -1,0 +1,13 @@
+package io.github.tobia80.dref.raft.proto
+
+/** PostgreSQL-backed Raft persistence for multi-node clusters on ephemeral pods.
+  *
+  * Each node stores its voter state and state-machine snapshot under its stable `nodeId`, so a plain Kubernetes
+  * `Deployment` (no per-pod volume) is safe as long as every replica uses a distinct `nodeId` and connects to the same
+  * DB.
+  */
+final case class RaftPostgresConfig(
+  jdbcUrl: String,
+  user: Option[String] = None,
+  password: Option[String] = None
+)

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/RaftPostgresStorage.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/RaftPostgresStorage.scala
@@ -1,0 +1,147 @@
+package io.github.tobia80.dref.raft.proto
+
+import io.github.tobia80.dref_consensus.ClusterSnapshot
+import zio.*
+
+import java.sql.{Connection, DriverManager}
+import java.util.Properties
+
+object RaftPostgresStorage {
+
+  private val VoterTable = "dref_raft_voter_state"
+  private val SnapshotTable = "dref_raft_state_snapshot"
+
+  private val SchemaSql =
+    s"""CREATE TABLE IF NOT EXISTS $VoterTable (
+       |  node_id TEXT PRIMARY KEY,
+       |  payload BYTEA NOT NULL
+       |);
+       |CREATE TABLE IF NOT EXISTS $SnapshotTable (
+       |  node_id TEXT PRIMARY KEY,
+       |  payload BYTEA NOT NULL
+       |);""".stripMargin
+
+  def voterStateStore(config: RaftPostgresConfig, nodeId: String): Task[VoterStateStore] =
+    open(config).map(new PostgresVoterStateStore(_, nodeId))
+
+  def snapshotStore(config: RaftPostgresConfig, nodeId: String): Task[StateMachineSnapshotStore] =
+    open(config).map(new PostgresSnapshotStore(_, nodeId))
+
+  private def open(config: RaftPostgresConfig): Task[SimpleDataSource] =
+    ZIO.attemptBlocking {
+      Class.forName("org.postgresql.Driver")
+      val ds = new SimpleDataSource(config)
+      ds.ensureSchema()
+      ds
+    }
+
+  private def connectionProperties(config: RaftPostgresConfig): Properties = {
+    val props = new Properties()
+    config.user.foreach(props.setProperty("user", _))
+    config.password.foreach(props.setProperty("password", _))
+    props
+  }
+
+  final private class SimpleDataSource(config: RaftPostgresConfig) {
+    private val props = connectionProperties(config)
+
+    def withConnection[A](f: Connection => A): A = {
+      val conn = DriverManager.getConnection(config.jdbcUrl, props)
+      try f(conn)
+      finally conn.close()
+    }
+
+    def ensureSchema(): Unit =
+      withConnection { conn =>
+        val stmt = conn.createStatement()
+        try stmt.execute(SchemaSql)
+        finally stmt.close()
+      }
+  }
+
+  final private class PostgresVoterStateStore(ds: SimpleDataSource, nodeId: String) extends VoterStateStore {
+
+    private val upsertSql =
+      s"INSERT INTO $VoterTable (node_id, payload) VALUES (?, ?) " +
+        s"ON CONFLICT (node_id) DO UPDATE SET payload = EXCLUDED.payload"
+
+    def load: Task[VoterState] =
+      ZIO.attemptBlocking {
+        ds.withConnection { conn =>
+          val stmt = conn.prepareStatement(s"SELECT payload FROM $VoterTable WHERE node_id = ?")
+          try {
+            stmt.setString(1, nodeId)
+            val rs = stmt.executeQuery()
+            try
+              if rs.next() then RaftStorageCodec.decodeVoterState(rs.getBytes(1))
+              else VoterState.empty
+            finally rs.close()
+          } finally stmt.close()
+        }
+      }
+
+    def save(state: VoterState): Task[Unit] =
+      ZIO.attemptBlocking {
+        val payload = RaftStorageCodec.encodeVoterState(state)
+        ds.withConnection { conn =>
+          conn.setAutoCommit(false)
+          try {
+            val stmt = conn.prepareStatement(upsertSql)
+            try {
+              stmt.setString(1, nodeId)
+              stmt.setBytes(2, payload)
+              stmt.executeUpdate()
+            } finally stmt.close()
+            conn.commit()
+          } catch {
+            case t: Throwable =>
+              conn.rollback()
+              throw t
+          } finally conn.setAutoCommit(true)
+        }
+      }
+  }
+
+  final private class PostgresSnapshotStore(ds: SimpleDataSource, nodeId: String) extends StateMachineSnapshotStore {
+
+    private val upsertSql =
+      s"INSERT INTO $SnapshotTable (node_id, payload) VALUES (?, ?) " +
+        s"ON CONFLICT (node_id) DO UPDATE SET payload = EXCLUDED.payload"
+
+    def load: Task[Option[ClusterSnapshot]] =
+      ZIO.attemptBlocking {
+        ds.withConnection { conn =>
+          val stmt = conn.prepareStatement(s"SELECT payload FROM $SnapshotTable WHERE node_id = ?")
+          try {
+            stmt.setString(1, nodeId)
+            val rs = stmt.executeQuery()
+            try
+              if rs.next() then Some(RaftStorageCodec.decodeSnapshot(rs.getBytes(1)))
+              else None
+            finally rs.close()
+          } finally stmt.close()
+        }
+      }
+
+    def save(snapshot: ClusterSnapshot): Task[Unit] =
+      ZIO.attemptBlocking {
+        val payload = RaftStorageCodec.encodeSnapshot(snapshot)
+        ds.withConnection { conn =>
+          conn.setAutoCommit(false)
+          try {
+            val stmt = conn.prepareStatement(upsertSql)
+            try {
+              stmt.setString(1, nodeId)
+              stmt.setBytes(2, payload)
+              stmt.executeUpdate()
+            } finally stmt.close()
+            conn.commit()
+          } catch {
+            case t: Throwable =>
+              conn.rollback()
+              throw t
+          } finally conn.setAutoCommit(true)
+        }
+      }
+  }
+}

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/RaftStorageCodec.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/RaftStorageCodec.scala
@@ -1,0 +1,101 @@
+package io.github.tobia80.dref.raft.proto
+
+import io.github.tobia80.dref_consensus.ClusterSnapshot
+
+import java.io.{
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  DataInputStream,
+  DataOutputStream,
+  EOFException,
+  IOException
+}
+import java.nio.charset.StandardCharsets
+
+/** Shared on-disk / database wire formats for Raft persistence stores. */
+private[proto] object RaftStorageCodec {
+
+  val VoterStateMagic: Int = 0x44524654 // "DRFT"
+  val SnapshotMagic: Int = 0x44524653 // "DRFS"
+  val Version: Byte = 1
+
+  def encodeVoterState(state: VoterState): Array[Byte] = {
+    val out = new ByteArrayOutputStream()
+    val data = new DataOutputStream(out)
+    writeVoterState(data, state)
+    data.flush()
+    out.toByteArray
+  }
+
+  def decodeVoterState(bytes: Array[Byte]): VoterState = {
+    val in = new DataInputStream(new ByteArrayInputStream(bytes))
+    try readVoterState(in)
+    catch case _: EOFException => throw new IOException("voter-state payload truncated")
+  }
+
+  def encodeSnapshot(snapshot: ClusterSnapshot): Array[Byte] = {
+    val out = new ByteArrayOutputStream()
+    val data = new DataOutputStream(out)
+    writeSnapshot(data, snapshot)
+    data.flush()
+    out.toByteArray
+  }
+
+  def decodeSnapshot(bytes: Array[Byte]): ClusterSnapshot = {
+    val in = new DataInputStream(new ByteArrayInputStream(bytes))
+    try readSnapshot(in)
+    catch case _: EOFException => throw new IOException("state-snapshot payload truncated")
+  }
+
+  private def readVoterState(in: DataInputStream): VoterState = {
+    val magic = in.readInt()
+    if magic != VoterStateMagic then
+      throw new IOException(f"voter-state magic mismatch: expected 0x${VoterStateMagic}%08x got 0x$magic%08x")
+    val version = in.readByte()
+    if version != Version then throw new IOException(s"voter-state version $version not supported")
+    val term = in.readLong()
+    val len = in.readInt()
+    val votedFor =
+      if len < 0 then None
+      else {
+        val bytes = new Array[Byte](len)
+        in.readFully(bytes)
+        Some(new String(bytes, StandardCharsets.UTF_8))
+      }
+    VoterState(term, votedFor)
+  }
+
+  private def writeVoterState(out: DataOutputStream, state: VoterState): Unit = {
+    out.writeInt(VoterStateMagic)
+    out.writeByte(Version)
+    out.writeLong(state.term)
+    state.votedFor match {
+      case None     => out.writeInt(-1)
+      case Some(id) =>
+        val bytes = id.getBytes(StandardCharsets.UTF_8)
+        out.writeInt(bytes.length)
+        out.write(bytes)
+    }
+  }
+
+  private def readSnapshot(in: DataInputStream): ClusterSnapshot = {
+    val magic = in.readInt()
+    if magic != SnapshotMagic then
+      throw new IOException(f"state-snapshot magic mismatch: expected 0x${SnapshotMagic}%08x got 0x$magic%08x")
+    val version = in.readByte()
+    if version != Version then throw new IOException(s"state-snapshot version $version not supported")
+    val len = in.readInt()
+    if len < 0 then throw new IOException(s"state-snapshot length negative: $len")
+    val payload = new Array[Byte](len)
+    in.readFully(payload)
+    ClusterSnapshot.parseFrom(payload)
+  }
+
+  private def writeSnapshot(out: DataOutputStream, snapshot: ClusterSnapshot): Unit = {
+    val payload = snapshot.toByteArray
+    out.writeInt(SnapshotMagic)
+    out.writeByte(Version)
+    out.writeInt(payload.length)
+    out.write(payload)
+  }
+}

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/StateMachineSnapshotStore.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/StateMachineSnapshotStore.scala
@@ -3,15 +3,15 @@ package io.github.tobia80.dref.raft.proto
 import io.github.tobia80.dref_consensus.ClusterSnapshot
 import zio.*
 
-import java.io.{DataInputStream, DataOutputStream, EOFException, FileInputStream, FileOutputStream, IOException}
+import java.io.{EOFException, FileOutputStream, IOException}
 import java.nio.file.{Files, Path, StandardCopyOption}
 
 /** Persists the Raft state machine's [[ClusterSnapshot]] to disk.
   *
   * The voter state store ([[VoterStateStore]]) makes the node Raft-safe across restarts; this store closes the
-  * companion gap on the *application* side. Without it, a restarted node boots with an empty in-memory state and has
-  * to be re-seeded by the leader's `InstallSnapshot` RPC. That works, but it adds avoidable network cost and recovery
-  * time on every restart — especially painful for clusters with large key sets or thin leader↔follower bandwidth.
+  * companion gap on the *application* side. Without it, a restarted node boots with an empty in-memory state and has to
+  * be re-seeded by the leader's `InstallSnapshot` RPC. That works, but it adds avoidable network cost and recovery time
+  * on every restart — especially painful for clusters with large key sets or thin leader↔follower bandwidth.
   *
   * The on-disk format mirrors the voter-state file: a fixed magic prefix, a one-byte version, then the protobuf
   * payload. Writes go through a temp file + fsync + atomic rename, so a crash mid-write either leaves the previous
@@ -24,8 +24,6 @@ trait StateMachineSnapshotStore {
 }
 
 object StateMachineSnapshotStore {
-  private val Magic: Int = 0x44524653 // "DRFS"
-  private val Version: Byte = 1
   private val FileName = "state-snapshot"
   private val TmpSuffix = ".tmp"
 
@@ -49,46 +47,21 @@ object StateMachineSnapshotStore {
     def load: Task[Option[ClusterSnapshot]] =
       ZIO.attemptBlocking {
         if !Files.exists(target) then None
-        else {
-          val in = new DataInputStream(new FileInputStream(target.toFile))
-          try Some(readSnapshot(in))
+        else
+          try Some(RaftStorageCodec.decodeSnapshot(Files.readAllBytes(target)))
           catch case _: EOFException => throw new IOException(s"state-snapshot file truncated: $target")
-          finally in.close()
-        }
       }
 
     def save(snapshot: ClusterSnapshot): Task[Unit] =
       ZIO.attemptBlocking {
         val out = new FileOutputStream(tmp.toFile)
         try {
-          val data = new DataOutputStream(out)
-          writeSnapshot(data, snapshot)
-          data.flush()
+          out.write(RaftStorageCodec.encodeSnapshot(snapshot))
+          out.flush()
           out.getFD.sync()
         } finally out.close()
         Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
         ()
       }
-  }
-
-  private def readSnapshot(in: DataInputStream): ClusterSnapshot = {
-    val magic = in.readInt()
-    if magic != Magic then
-      throw new IOException(f"state-snapshot magic mismatch: expected 0x${Magic}%08x got 0x$magic%08x")
-    val version = in.readByte()
-    if version != Version then throw new IOException(s"state-snapshot version $version not supported")
-    val len = in.readInt()
-    if len < 0 then throw new IOException(s"state-snapshot length negative: $len")
-    val payload = new Array[Byte](len)
-    in.readFully(payload)
-    ClusterSnapshot.parseFrom(payload)
-  }
-
-  private def writeSnapshot(out: DataOutputStream, snapshot: ClusterSnapshot): Unit = {
-    val payload = snapshot.toByteArray
-    out.writeInt(Magic)
-    out.writeByte(Version)
-    out.writeInt(payload.length)
-    out.write(payload)
   }
 }

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/VoterStateStore.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/VoterStateStore.scala
@@ -2,8 +2,7 @@ package io.github.tobia80.dref.raft.proto
 
 import zio.*
 
-import java.io.{DataInputStream, DataOutputStream, EOFException, FileInputStream, FileOutputStream, IOException}
-import java.nio.charset.StandardCharsets
+import java.io.{EOFException, FileOutputStream, IOException}
 import java.nio.file.{Files, Path, StandardCopyOption}
 
 final case class VoterState(term: Long, votedFor: Option[String])
@@ -23,8 +22,6 @@ trait VoterStateStore {
 }
 
 object VoterStateStore {
-  private val Magic: Int = 0x44524654 // "DRFT"
-  private val Version: Byte = 1
   private val FileName = "voter-state"
   private val TmpSuffix = ".tmp"
 
@@ -48,56 +45,21 @@ object VoterStateStore {
     def load: Task[VoterState] =
       ZIO.attemptBlocking {
         if !Files.exists(target) then VoterState.empty
-        else {
-          val in = new DataInputStream(new FileInputStream(target.toFile))
-          try readState(in)
+        else
+          try RaftStorageCodec.decodeVoterState(Files.readAllBytes(target))
           catch case _: EOFException => throw new IOException(s"voter-state file truncated: $target")
-          finally in.close()
-        }
       }
 
     def save(state: VoterState): Task[Unit] =
       ZIO.attemptBlocking {
         val out = new FileOutputStream(tmp.toFile)
         try {
-          val data = new DataOutputStream(out)
-          writeState(data, state)
-          data.flush()
+          out.write(RaftStorageCodec.encodeVoterState(state))
+          out.flush()
           out.getFD.sync()
         } finally out.close()
         Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
         ()
       }
-  }
-
-  private def readState(in: DataInputStream): VoterState = {
-    val magic = in.readInt()
-    if magic != Magic then
-      throw new IOException(f"voter-state magic mismatch: expected 0x${Magic}%08x got 0x$magic%08x")
-    val version = in.readByte()
-    if version != Version then throw new IOException(s"voter-state version $version not supported")
-    val term = in.readLong()
-    val len = in.readInt()
-    val votedFor =
-      if len < 0 then None
-      else {
-        val bytes = new Array[Byte](len)
-        in.readFully(bytes)
-        Some(new String(bytes, StandardCharsets.UTF_8))
-      }
-    VoterState(term, votedFor)
-  }
-
-  private def writeState(out: DataOutputStream, state: VoterState): Unit = {
-    out.writeInt(Magic)
-    out.writeByte(Version)
-    out.writeLong(state.term)
-    state.votedFor match {
-      case None     => out.writeInt(-1)
-      case Some(id) =>
-        val bytes = id.getBytes(StandardCharsets.UTF_8)
-        out.writeInt(bytes.length)
-        out.write(bytes)
-    }
   }
 }

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/RaftPostgresStorageSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/RaftPostgresStorageSpec.scala
@@ -1,0 +1,60 @@
+package io.github.tobia80.dref.raft
+
+import io.github.tobia80.dref.raft.proto.{RaftPostgresConfig, RaftPostgresStorage, VoterState}
+import zio.*
+import zio.test.*
+
+object RaftPostgresStorageSpec extends ZIOSpecDefault {
+
+  private val postgresConfig: RaftPostgresConfig = RaftPostgresConfig(
+    jdbcUrl = sys.env.getOrElse("DREF_TEST_POSTGRES_JDBC_URL", "jdbc:postgresql://localhost:5432/dref_test"),
+    user = Some(sys.env.getOrElse("DREF_TEST_POSTGRES_USER", "postgres")),
+    password = Some(sys.env.getOrElse("DREF_TEST_POSTGRES_PASSWORD", "test"))
+  )
+
+  private val postgresAvailable: UIO[Boolean] =
+    RaftPostgresStorage
+      .voterStateStore(postgresConfig, "postgres-probe")
+      .fold(_ => false, _ => true)
+
+  private def uniqueNodeId(prefix: String): UIO[String] =
+    Random.nextUUID.map(id => s"$prefix-$id")
+
+  private val postgresTests = suite("RaftPostgresStorage")(
+    test("voter state save then load round-trips") {
+      for {
+        nodeId <- uniqueNodeId("voter")
+        store  <- RaftPostgresStorage.voterStateStore(postgresConfig, nodeId)
+        _      <- store.save(VoterState(42L, Some("node-7")))
+        loaded <- store.load
+      } yield assertTrue(loaded == VoterState(42L, Some("node-7")))
+    },
+    test("two node ids are isolated") {
+      for {
+        nodeA  <- uniqueNodeId("a")
+        nodeB  <- uniqueNodeId("b")
+        storeA <- RaftPostgresStorage.voterStateStore(postgresConfig, nodeA)
+        storeB <- RaftPostgresStorage.voterStateStore(postgresConfig, nodeB)
+        _      <- storeA.save(VoterState(10L, Some("alpha")))
+        _      <- storeB.save(VoterState(20L, Some("beta")))
+        readA  <- storeA.load
+        readB  <- storeB.load
+      } yield assertTrue(
+        readA == VoterState(10L, Some("alpha")),
+        readB == VoterState(20L, Some("beta"))
+      )
+    },
+    test("snapshot save then load round-trips") {
+      import io.github.tobia80.dref_consensus.ClusterSnapshot
+      for {
+        nodeId <- uniqueNodeId("snapshot")
+        store  <- RaftPostgresStorage.snapshotStore(postgresConfig, nodeId)
+        snap    = ClusterSnapshot(lastSeq = 99L)
+        _      <- store.save(snap)
+        loaded <- store.load
+      } yield assertTrue(loaded.contains(snap))
+    }
+  ) @@ TestAspect.sequential
+
+  override def spec: Spec[TestEnvironment, Any] = postgresTests.whenZIO(postgresAvailable)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Raft nodes can now persist voter state (`currentTerm`, `votedFor`) and state-machine snapshots to **PostgreSQL** instead of a local `storageDir`. Each row is keyed by the node's stable `nodeId`, so a multi-node cluster can run as a plain Kubernetes **Deployment** (ephemeral pods) with a shared Postgres instance—no StatefulSet or per-pod PVC required.

## Usage

```scala
ProtoRaftConfig(
  port = 8082,
  nodeId = Some("node-1"), // must be stable across restarts for this pod/replica
  postgres = Some(RaftPostgresConfig(
    jdbcUrl = "jdbc:postgresql://postgres:5432/dref",
    user = Some("dref"),
    password = Some(sys.env("DREF_DB_PASSWORD")),
  )),
  snapshotEvery = 1000,
)
```

When `postgres` is set it takes precedence over `storageDir`. The on-wire BYTEA payload uses the same DRFT/DRFS format as the file stores (shared `RaftStorageCodec`), preserving cross-language compatibility with the Rust port's file backend.

## Schema

On first connect the library creates (if missing):

- `dref_raft_voter_state (node_id, payload)`
- `dref_raft_state_snapshot (node_id, payload)`

## Testing

- New `RaftPostgresStorageSpec` (skipped when Postgres is unreachable)
- CI: postgres:16 service + `DREF_TEST_POSTGRES_*` env vars on the Scala job

## Notes

- Rust `RaftConfig` still uses `storage_dir` only; the BYTEA format is compatible when a Rust postgres backend is added later.
- Each replica must have a **distinct** `nodeId`; do not run multiple Raft peers with the same id against the same DB rows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2b2d24f-4423-4b6f-9284-d28723dabc9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2b2d24f-4423-4b6f-9284-d28723dabc9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

