### PR TITLE
Raft quorum commit, linearizable reads, and command log

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ ProtoRaftConfig(
 )
 ```
 
+**On-disk layout (per node):**
+
+```
+{storageDir}/
+  voter-state          # DRFT — term + votedFor
+  state-snapshot       # DRFS — full ClusterSnapshot
+  command-log          # DRFL — append-only log + commit index
+```
+
+The command log is fsync'd **before** a replication ack counts toward quorum. After a state-machine snapshot is written, entries at or below the commit index are truncated from the log.
+
 If `storageDir` is `None` (the default), the node keeps voter state and
 snapshots in memory only. That is fine for single-process tests but unsafe for
 multi-node clusters: a node that restarts without persistent `votedFor` can
@@ -228,19 +239,32 @@ grant a second vote in the same term, and a node that restarts without a
 snapshot must be reseeded by the leader. Deploy multi-node Raft clusters with a
 per-node PersistentVolumeClaim (or equivalent) rather than a plain `Deployment`.
 
-Snapshots are full state-machine images, not durable Raft log segments. The
-current consensus engine uses monotonic sequence numbers and `InstallSnapshot`
-catch-up instead of maintaining a persistent command log, so there is no log to
-truncate. This keeps restart and lagging-follower recovery bounded in the
-current simplified model, but it is not a full Raft §7 log-compaction
-implementation.
+Snapshots are full state-machine images. The command log (`DRFL`) holds
+entries not yet covered by a snapshot; it is truncated after each snapshot
+write. Lagging followers are caught up via `InstallSnapshot` rather than
+log replay from arbitrary indices.
 
 The on-disk voter-state format is shared with the Rust port (magic `DRFT`,
 big-endian fields, atomic rename + `fsync` on every write); see
 [`compat/voter_state_vectors.json`](compat/voter_state_vectors.json). The
 state-machine snapshot format is shared as well (magic `DRFS`, protobuf
 `ClusterSnapshot`, atomic rename + `fsync`); see
-[`compat/snapshot_vectors.json`](compat/snapshot_vectors.json).
+[`compat/snapshot_vectors.json`](compat/snapshot_vectors.json). The
+command-log format is shared as well (magic `DRFL`, big-endian header +
+records, append + fsync); see
+[`compat/command_log_vectors.json`](compat/command_log_vectors.json).
+
+## Raft consistency guarantees
+
+| Operation | Guarantee |
+|-----------|-----------|
+| **Write** (`set`, `delete`, …) | **Linearizable write**: the leader responds only after the entry is stored on a **majority** of nodes. If fewer than a quorum are reachable, the write fails with `quorum-lost`. |
+| **Read** (`get`) | **Linearizable read**: routed to the leader, which confirms leadership with a **ReadIndex** quorum probe before serving from committed state. Followers reject reads (`NotLeader`). |
+| **Change stream** | **Eventual** on each node: followers apply committed entries after the leader propagates the commit index (typically immediately after each write). |
+
+Writes and reads both require a healthy quorum. A partitioned leader cannot commit new writes or serve linearizable reads once it can no longer reach a majority.
+
+The engine persists an append-only command log (`command-log`, magic `DRFL`) before counting replication acks toward quorum. Durability across leader restart combines the log with state-machine snapshots and the shared voter-state file; the log is truncated when snapshots catch up.
 
 ## Cross-language compatibility
 
@@ -253,6 +277,7 @@ layer or sidecar is required.
 | **Core values & locks** | MsgPack codec (`rmp-serde` / `zio-schema-msg-pack`), 8-byte big-endian lock tokens | [`compat/vectors.json`](compat/vectors.json), `CrossLangCompatSpec` (Scala), `compat_tests` (Rust) |
 | **Raft state commands** | [`proto/state_command.proto`](proto/state_command.proto) | [`compat/consensus_vectors.json`](compat/consensus_vectors.json), `CrossLangConsensusCompatSpec` (Scala), `consensus_compat_tests` (Rust) |
 | **Raft snapshots** | `ClusterSnapshot` in [`proto/dref_consensus.proto`](proto/dref_consensus.proto), plus the shared on-disk wrapper | [`compat/snapshot_vectors.json`](compat/snapshot_vectors.json), `StateMachineSnapshotStoreSpec` (Scala), `crosslang_snapshot_tests` (Rust) |
+| **Raft command log** | On-disk `command-log` file (magic `DRFL`) | [`compat/command_log_vectors.json`](compat/command_log_vectors.json), `CommandLogStoreSpec` (Scala), `crosslang_command_log_tests` (Rust) |
 | **Inter-node RPC** | [`proto/dref.proto`](proto/dref.proto), [`proto/dref_consensus.proto`](proto/dref_consensus.proto) | `ProtoRaftDRefSpec` (Scala), `raft_tests` (Rust) |
 | **Redis backend** | Same key layout, TTL semantics, and keyspace-notification payloads | `CrossLangRedisSpec` (Scala), `crosslang_redis_tests` (Rust) |
 

--- a/compat/command_log_vectors.json
+++ b/compat/command_log_vectors.json
@@ -1,0 +1,17 @@
+{
+  "description": "Golden on-disk bytes for CommandLogStore (magic DRFL) shared by Scala and Rust.",
+  "vectors": [
+    {
+      "name": "empty_header",
+      "commit_seq": 0,
+      "hex": "4452464c010000000000000000"
+    },
+    {
+      "name": "single_set_element_record",
+      "commit_seq": 0,
+      "seq": 1,
+      "command_payload_hex": "0a130a066d792d6b657912030102031880e2cfaa06",
+      "hex": "4452464c0100000000000000000000000000000001000000150a130a066d792d6b657912030102031880e2cfaa06"
+    }
+  ]
+}

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/CommandLogStore.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/CommandLogStore.scala
@@ -1,0 +1,171 @@
+package io.github.tobia80.dref.raft.proto
+
+import zio.*
+
+import java.io.{DataInputStream, DataOutputStream, EOFException, FileInputStream, FileOutputStream, IOException, RandomAccessFile}
+import java.nio.file.{Files, Path, StandardCopyOption}
+
+/** One persisted command log entry keyed by monotonic sequence number. */
+final case class CommandLogEntry(seq: Long, command: Array[Byte])
+
+/** Loaded command log state: durable commit index plus all stored entries. */
+final case class CommandLogState(commitSeq: Long, entries: Map[Long, Array[Byte]])
+
+object CommandLogState {
+  val empty: CommandLogState = CommandLogState(0L, Map.empty)
+}
+
+/** Append-only command log persisted before replication acks.
+  *
+  * Wire format (big-endian, shared with the Rust port):
+  *   header: magic "DRFL" (4) | version 1 (1) | commit_seq u64 (8)
+  *   record: seq u64 (8) | command_len i32 (4) | command bytes
+  */
+trait CommandLogStore {
+  def load: Task[CommandLogState]
+  def append(seq: Long, command: Array[Byte]): Task[Unit]
+  def setCommitSeq(commitSeq: Long): Task[Unit]
+  /** Drop every record with `seq <= throughSeq` and clamp the header commit index. */
+  def truncateThrough(throughSeq: Long): Task[Unit]
+}
+
+object CommandLogStore {
+  private val Magic: Int = 0x4452464c // "DRFL"
+  private val Version: Byte = 1
+  private val HeaderSize: Int = 13
+  private val FileName = "command-log"
+  private val TmpSuffix = ".tmp"
+
+  val noop: CommandLogStore = new CommandLogStore {
+    def load: Task[CommandLogState] = ZIO.succeed(CommandLogState.empty)
+    def append(seq: Long, command: Array[Byte]): Task[Unit] = ZIO.unit
+    def setCommitSeq(commitSeq: Long): Task[Unit] = ZIO.unit
+    def truncateThrough(throughSeq: Long): Task[Unit] = ZIO.unit
+  }
+
+  def file(dir: Path): Task[CommandLogStore] =
+    ZIO
+      .attemptBlocking(Files.createDirectories(dir))
+      .as(new FileStore(dir))
+
+  final private class FileStore(dir: Path) extends CommandLogStore {
+    private val target = dir.resolve(FileName)
+    private val tmp = dir.resolve(FileName + TmpSuffix)
+
+    def load: Task[CommandLogState] =
+      ZIO.attemptBlocking {
+        if !Files.exists(target) then CommandLogState.empty
+        else {
+          val in = new DataInputStream(new FileInputStream(target.toFile))
+          try readLog(in)
+          catch case _: EOFException => throw new IOException(s"command-log file truncated: $target")
+          finally in.close()
+        }
+      }
+
+    def append(seq: Long, command: Array[Byte]): Task[Unit] =
+      ZIO.attemptBlocking {
+        ensureHeader()
+        val out = new FileOutputStream(target.toFile, true)
+        try {
+          val data = new DataOutputStream(out)
+          data.writeLong(seq)
+          data.writeInt(command.length)
+          data.write(command)
+          data.flush()
+          out.getFD.sync()
+        } finally out.close()
+      }
+
+    def setCommitSeq(commitSeq: Long): Task[Unit] =
+      ZIO.attemptBlocking {
+        ensureHeader()
+        val raf = new RandomAccessFile(target.toFile, "rw")
+        try {
+          raf.seek(5L)
+          raf.writeLong(commitSeq)
+          raf.getFD.sync()
+        } finally raf.close()
+      }
+
+    def truncateThrough(throughSeq: Long): Task[Unit] =
+      ZIO.attemptBlocking {
+        if !Files.exists(target) then ()
+        else {
+          val in = new DataInputStream(new FileInputStream(target.toFile))
+          val (commitSeq, entries) =
+            try readLog(in)
+            finally in.close()
+          val kept = entries.filter { case (seq, _) => seq > throughSeq }
+          val newCommit = math.min(commitSeq, throughSeq)
+          rewrite(newCommit, kept)
+        }
+      }
+
+    private def ensureHeader(): Unit =
+      if !Files.exists(target) then {
+        val out = new FileOutputStream(target.toFile)
+        try {
+          val data = new DataOutputStream(out)
+          data.writeInt(Magic)
+          data.writeByte(Version)
+          data.writeLong(0L)
+          data.flush()
+          out.getFD.sync()
+        } finally out.close()
+      }
+
+    private def rewrite(commitSeq: Long, entries: Map[Long, Array[Byte]]): Unit = {
+      val out = new FileOutputStream(tmp.toFile)
+      try {
+        val data = new DataOutputStream(out)
+        data.writeInt(Magic)
+        data.writeByte(Version)
+        data.writeLong(commitSeq)
+        entries.toList.sortBy(_._1).foreach { case (seq, command) =>
+          data.writeLong(seq)
+          data.writeInt(command.length)
+          data.write(command)
+        }
+        data.flush()
+        out.getFD.sync()
+      } finally out.close()
+      Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+      ()
+    }
+  }
+
+  private def readLog(in: DataInputStream): CommandLogState = {
+    val magic = in.readInt()
+    if magic != Magic then
+      throw new IOException(f"command-log magic mismatch: expected 0x${Magic}%08x got 0x$magic%08x")
+    val version = in.readByte()
+    if version != Version then throw new IOException(s"command-log version $version not supported")
+    val commitSeq = in.readLong()
+    val entries = scala.collection.mutable.Map.empty[Long, Array[Byte]]
+    try
+      while true do
+        val seq = in.readLong()
+        val len = in.readInt()
+        if len < 0 then throw new IOException(s"command-log negative command length at seq $seq")
+        val command = new Array[Byte](len)
+        in.readFully(command)
+        entries.update(seq, command)
+    catch case _: EOFException => ()
+    CommandLogState(commitSeq, entries.toMap)
+  }
+
+  /** Encode a single record for golden-vector tests (header + one entry). */
+  def encodeForTest(entry: CommandLogEntry, commitSeq: Long = 0L): Array[Byte] = {
+    val out = new java.io.ByteArrayOutputStream()
+    val data = new DataOutputStream(out)
+    data.writeInt(Magic)
+    data.writeByte(Version)
+    data.writeLong(commitSeq)
+    data.writeLong(entry.seq)
+    data.writeInt(entry.command.length)
+    data.write(entry.command)
+    data.flush()
+    out.toByteArray
+  }
+}

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/CommandLogStore.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/CommandLogStore.scala
@@ -93,11 +93,12 @@ object CommandLogStore {
         if !Files.exists(target) then ()
         else {
           val in = new DataInputStream(new FileInputStream(target.toFile))
-          val (commitSeq, entries) =
+          val loaded =
             try readLog(in)
+            catch case _: EOFException => throw new IOException(s"command-log file truncated: $target")
             finally in.close()
-          val kept = entries.filter { case (seq, _) => seq > throughSeq }
-          val newCommit = math.min(commitSeq, throughSeq)
+          val kept = loaded.entries.filter { case (seq, _) => seq > throughSeq }
+          val newCommit = math.min(loaded.commitSeq, throughSeq)
           rewrite(newCommit, kept)
         }
       }

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/DRefConsensusGrpcServer.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/DRefConsensusGrpcServer.scala
@@ -17,7 +17,8 @@ final class DRefConsensusGrpcServer(consensus: ProtoConsensusEngine) extends ZDR
         request.leaderId,
         request.term,
         request.seq,
-        request.command.toByteArray
+        request.command.toByteArray,
+        request.commitSeq
       )
       .map { case (success, term) => AppendEntriesResponse(success, term) }
 
@@ -26,8 +27,16 @@ final class DRefConsensusGrpcServer(consensus: ProtoConsensusEngine) extends ZDR
     context: RequestContext
   ): IO[StatusException, HeartbeatResponse] =
     consensus
-      .handleHeartbeat(request.leaderId, request.term)
+      .handleHeartbeat(request.leaderId, request.term, request.commitSeq)
       .map { case (acknowledged, term) => HeartbeatResponse(acknowledged, term) }
+
+  override def readIndex(
+    request: ReadIndexRequest,
+    context: RequestContext
+  ): IO[StatusException, ReadIndexResponse] =
+    consensus
+      .handleReadIndex(request.leaderId, request.term)
+      .map { case (granted, term) => ReadIndexResponse(granted, term) }
 
   override def requestVote(
     request: VoteRequest,

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
@@ -18,6 +18,8 @@ final private case class ConsensusState(
   votedFor: Option[String],
   leaderId: Option[String],
   lastSeq: Long,
+  commitSeq: Long,
+  lastApplied: Long,
   lastHeartbeatNanos: Long
 )
 
@@ -32,6 +34,12 @@ object ConsensusError {
   case object NoLeader extends ConsensusError {
     override def getMessage: String = "no leader is currently elected"
   }
+
+  /** Returned when the leader cannot replicate a write to a majority of the cluster. */
+  case object QuorumLost extends ConsensusError {
+    override def getMessage: String = "write could not be replicated to a quorum"
+  }
+
   final case class Serialize(message: String) extends ConsensusError
   final case class Transport(message: String) extends ConsensusError
 }
@@ -42,8 +50,11 @@ final class ProtoConsensusEngine private (
   peersRef: Ref[Map[String, DRefConsensusClient]],
   config: ProtoRaftConfig,
   stateRef: Ref[ConsensusState],
+  pendingRef: Ref[Map[Long, Array[Byte]]],
   voterStore: VoterStateStore,
+  commandLogStore: CommandLogStore,
   persistMutex: Semaphore,
+  logMutex: Semaphore,
   snapshotStore: StateMachineSnapshotStore,
   snapshotMutex: Semaphore,
   appliesSinceSnapshot: Ref[Long]
@@ -92,6 +103,9 @@ final class ProtoConsensusEngine private (
       } yield result
     }
 
+  private def withCommandLog[A](op: CommandLogStore => Task[A]): UIO[A] =
+    logMutex.withPermit(op(commandLogStore).orDie)
+
   /** Record that a command was successfully applied. When the running tally crosses the configured
     * `snapshotEvery` threshold, fork off a snapshot write so the on-disk picture catches up.
     *
@@ -123,6 +137,7 @@ final class ProtoConsensusEngine private (
         st       <- stateRef.get
         snapshot <- stateMachine.takeSnapshot
         _        <- snapshotStore.save(snapshot.copy(lastSeq = st.lastSeq))
+        _        <- withCommandLog(_.truncateThrough(st.commitSeq))
       } yield ()
     }
 
@@ -139,6 +154,47 @@ final class ProtoConsensusEngine private (
     */
   def currentTerm: UIO[Long] = stateRef.get.map(_.term)
 
+  /** Apply pending entries up to `commitSeq` and advance the committed/applied markers. */
+  private def applyCommitted(commitSeq: Long): UIO[Unit] =
+    stateRef.get.flatMap { st =>
+      if commitSeq <= st.commitSeq then ZIO.unit
+      else
+        ZIO
+          .foldLeft((st.lastApplied + 1L) to commitSeq)(()) { (_, seq) =>
+            for {
+              pending <- pendingRef.get
+              _       <- pending.get(seq) match {
+                           case Some(value) =>
+                             for {
+                               cmd <- ZIO.attempt(StateCommand.parseFrom(value)).orDie
+                               _   <- stateMachine.apply(cmd)
+                               _   <- noteApplied
+                               _   <- stateRef.update(s => s.copy(lastApplied = seq))
+                               _   <- pendingRef.update(_ - seq)
+                             } yield ()
+                           case None =>
+                             ZIO.logWarning(s"missing pending entry for seq $seq")
+                         }
+            } yield ()
+          }
+          .flatMap(_ =>
+            stateRef.update(_.copy(commitSeq = commitSeq)) *>
+              withCommandLog(_.setCommitSeq(commitSeq))
+          )
+    }
+
+  /** Push the current commit index to every follower so they apply pending entries. */
+  private def propagateCommitSeq(commitSeq: Long, term: Long): UIO[Unit] =
+    peersRef.get.flatMap { peers =>
+      ZIO.foreachParDiscard(peers) { case (_, client) =>
+        client
+          .heartbeat(HeartbeatRequest(leaderId = nodeId, term = term, commitSeq = commitSeq))
+          .foldZIO(_ => ZIO.unit, resp => stepDownIfStale(resp.term))
+      }
+    }
+
+  private def quorumNeeded(peerCount: Int): Int = (peerCount + 1) / 2 + 1
+
   def submit(cmd: StateCommand): IO[ConsensusError, ApplyResult] =
     for {
       termAndSeq <- stateRef
@@ -146,24 +202,67 @@ final class ProtoConsensusEngine private (
                         if st.role != Role.Leader then (Left(ConsensusError.NotLeader(st.leaderId)), st)
                         else
                           val next = st.copy(lastSeq = st.lastSeq + 1)
-                          (Right((next.term, next.lastSeq)), next)
+                          (Right((next.term, next.lastSeq, next.commitSeq)), next)
                       }
                       .flatMap {
                         case Left(err)   => ZIO.fail(err)
-                        case Right(pair) => ZIO.succeed(pair)
+                        case Right(trip) => ZIO.succeed(trip)
                       }
-      (term, seq) = termAndSeq
-      bytes       = cmd.toByteArray
-      result     <- stateMachine.apply(cmd)
-      _          <- noteApplied
-      _          <- replicate(term, seq, bytes).forkDaemon.unit
+      (term, seq, commitSeqBefore) = termAndSeq
+      bytes                        = cmd.toByteArray
+      _                           <- withCommandLog(_.append(seq, bytes))
+      peers                       <- peersRef.get
+      needed                       = quorumNeeded(peers.size)
+      followerAcks                <- replicateForQuorum(term, seq, bytes, commitSeqBefore)
+      totalAcks                    = 1 + followerAcks
+      _                           <- ZIO.when(totalAcks < needed) {
+                                       withCommandLog(_.truncateThrough(seq - 1)) *>
+                                         stateRef.update(_.copy(lastSeq = seq - 1)) *>
+                                         ZIO.fail(ConsensusError.QuorumLost)
+                                     }
+      stillLeader                 <- isLeader
+      _                           <- ZIO.fail(ConsensusError.NotLeader(None)).when(!stillLeader)
+      result                      <- stateMachine.apply(cmd)
+      _                           <- noteApplied
+      _                           <- stateRef.update(s => s.copy(commitSeq = seq, lastApplied = seq))
+      _                           <- withCommandLog(_.setCommitSeq(seq))
+      _                           <- propagateCommitSeq(seq, term)
     } yield result
+
+  /** Confirm leadership with a quorum before serving a linearizable read. */
+  def readIndex: IO[ConsensusError, Unit] =
+    for {
+      st <- stateRef.get
+      _  <- ZIO.fail(ConsensusError.NotLeader(st.leaderId)).when(st.role != Role.Leader)
+      peers     <- peersRef.get
+      needed     = quorumNeeded(peers.size)
+      responses <- ZIO.foreachPar(peers.toList) { case (peerId, client) =>
+                     client
+                       .readIndex(ReadIndexRequest(leaderId = nodeId, term = st.term))
+                       .map(Some(_))
+                       .catchAll { _ =>
+                         ZIO.logDebug(s"read-index request failed for peer $peerId") *> ZIO.none
+                       }
+                   }
+      higherTerm = responses.flatten.collect { case resp if resp.term > st.term => resp.term }.headOption
+      _         <- higherTerm match {
+                     case Some(newTerm) => stepDownIfStale(newTerm) *> ZIO.fail(ConsensusError.NotLeader(None))
+                     case None          =>
+                       val grants = 1 + responses.flatten.count(_.granted)
+                       ZIO.fail(ConsensusError.NotLeader(st.leaderId)).when(grants < needed).unit
+                   }
+      applied <- stateRef.get.map(_.lastApplied)
+      _       <- ZIO
+                   .fail(ConsensusError.NotLeader(st.leaderId))
+                   .when(applied < st.commitSeq)
+    } yield ()
 
   def handleAppendEntries(
     leaderId: String,
     term: Long,
     seq: Long,
-    command: Array[Byte]
+    command: Array[Byte],
+    commitSeq: Long
   ): UIO[(Boolean, Long)] =
     for {
       updated                <- updateAndPersist { st =>
@@ -183,30 +282,37 @@ final class ProtoConsensusEngine private (
       (accepted, currentTerm) = updated
       result                 <-
         if accepted then
-          ZIO
-            .attempt(StateCommand.parseFrom(command))
-            .flatMap(stateMachine.apply)
-            .foldZIO(
-              _ => ZIO.succeed(false),
-              _ => noteApplied.as(true)
-            )
-            .map(ok => (ok, currentTerm))
+          withCommandLog(_.append(seq, command)) *>
+            pendingRef.update(_ + (seq -> command)) *>
+            applyCommitted(commitSeq).as((true, currentTerm))
         else ZIO.succeed((false, currentTerm))
     } yield result
 
-  def handleHeartbeat(leaderId: String, term: Long): UIO[(Boolean, Long)] =
-    updateAndPersist { st =>
-      if term < st.term then ((false, st.term), st)
-      else
-        val stepped =
-          if term > st.term then st.copy(term = term, votedFor = None)
-          else st
-        val next = stepped.copy(
-          role = Role.Follower,
-          leaderId = Some(leaderId),
-          lastHeartbeatNanos = java.lang.System.nanoTime()
-        )
-        ((true, next.term), next)
+  def handleHeartbeat(leaderId: String, term: Long, commitSeq: Long): UIO[(Boolean, Long)] =
+    for {
+      updated <- updateAndPersist { st =>
+                   if term < st.term then ((false, st.term), st)
+                   else
+                     val stepped =
+                       if term > st.term then st.copy(term = term, votedFor = None)
+                       else st
+                     val next = stepped.copy(
+                       role = Role.Follower,
+                       leaderId = Some(leaderId),
+                       lastHeartbeatNanos = java.lang.System.nanoTime()
+                     )
+                     ((true, next.term), next)
+                 }
+      (acknowledged, currentTerm) = updated
+      _                          <- applyCommitted(commitSeq).when(acknowledged)
+    } yield (acknowledged, currentTerm)
+
+  /** Follower ack for a ReadIndex probe — confirms the requester is still the leader we know. */
+  def handleReadIndex(leaderId: String, term: Long): UIO[(Boolean, Long)] =
+    stateRef.get.map { st =>
+      if term < st.term then (false, st.term)
+      else if st.leaderId.contains(leaderId) && term == st.term then (true, st.term)
+      else (false, st.term)
     }
 
   /** Handle a PreVote request (Ongaro thesis §9.6).
@@ -289,7 +395,12 @@ final class ProtoConsensusEngine private (
                                     // applies-counter and durably re-write the snapshot so a restart picks up the
                                     // freshly-received state instead of the leader's stale `lastSeq` gap.
                                     val durableSnapshot = snapshot.copy(lastSeq = lastSeq)
-                                    stateMachine.installSnapshot(durableSnapshot) *>
+                                    withCommandLog(_.truncateThrough(lastSeq)) *>
+                                      pendingRef.set(Map.empty) *>
+                                      stateMachine.installSnapshot(durableSnapshot) *>
+                                      stateRef.update(
+                                        _.copy(commitSeq = lastSeq, lastApplied = lastSeq)
+                                      ) *>
                                       appliesSinceSnapshot.set(0L) *>
                                       persistSnapshotInBackground
                                   }
@@ -298,32 +409,34 @@ final class ProtoConsensusEngine private (
   def spawnDrivers: UIO[Fiber.Runtime[Throwable, Nothing]] =
     driverLoop.forever.forkDaemon
 
-  private def replicate(term: Long, seq: Long, command: Array[Byte]): UIO[Unit] =
+  /** Replicate one entry and return the number of follower acks received. */
+  private def replicateForQuorum(
+    term: Long,
+    seq: Long,
+    command: Array[Byte],
+    commitSeq: Long
+  ): UIO[Int] =
     peersRef.get.flatMap { peers =>
-      ZIO.foreachParDiscard(peers) { case (peerId, client) =>
+      ZIO.foreachPar(peers.toList) { case (peerId, client) =>
         client
           .appendEntries(
             AppendEntriesRequest(
               leaderId = nodeId,
               term = term,
               command = ByteString.copyFrom(command),
-              seq = seq
+              seq = seq,
+              commitSeq = commitSeq
             )
           )
           .foldZIO(
-            _ => ZIO.unit,
+            _ => ZIO.succeed(false),
             resp =>
               stepDownIfStale(resp.term) *>
-                // A follower whose lastSeq diverges from ours rejects with
-                // success=false; without a catch-up the strict seq check keeps
-                // refusing every subsequent entry until a new election. Push a
-                // snapshot to bring them in sync as long as we're still the
-                // leader at this term.
                 ZIO.when(!resp.success && resp.term <= term) {
                   sendSnapshotTo(peerId, client)
-                }
+                }.as(resp.success)
           )
-      }
+      }.map(_.count(identity))
     }
 
   private def sendSnapshotTo(peerId: String, client: DRefConsensusClient): UIO[Unit] =
@@ -371,9 +484,9 @@ final class ProtoConsensusEngine private (
   private def sendHeartbeats: UIO[Unit] =
     stateRef.get.flatMap { st =>
       peersRef.get.flatMap { peers =>
-        ZIO.foreachParDiscard(peers) { case (peerId, client) =>
+        ZIO.foreachParDiscard(peers) { case (_, client) =>
           client
-            .heartbeat(HeartbeatRequest(leaderId = nodeId, term = st.term))
+            .heartbeat(HeartbeatRequest(leaderId = nodeId, term = st.term, commitSeq = st.commitSeq))
             .foldZIO(
               _ => ZIO.unit,
               resp => stepDownIfStale(resp.term)
@@ -540,12 +653,30 @@ object ProtoConsensusEngine {
                           case Some(path) => StateMachineSnapshotStore.file(path)
                           case None       => ZIO.succeed(StateMachineSnapshotStore.noop)
                         }
+      commandLogStore <- config.storageDir match {
+                          case Some(path) => CommandLogStore.file(path)
+                          case None       => ZIO.succeed(CommandLogStore.noop)
+                        }
       // Hydrate the state machine BEFORE peers come online so we don't serve
       // empty reads or accept appends against a stale lastSeq baseline. If the
       // snapshot file is corrupt or unreadable we fail-fast — silently booting
       // empty would diverge this node from the rest of the cluster.
       persisted      <- snapshotStore.load
       _              <- ZIO.foreachDiscard(persisted)(stateMachine.installSnapshot)
+      snapshotLastSeq = persisted.fold(0L)(_.lastSeq)
+      logState       <- commandLogStore.load
+      maxLogSeq       = logState.entries.keys.maxOption.getOrElse(0L)
+      recoveredCommit = math.min(logState.commitSeq, maxLogSeq)
+      initialCommitSeq = math.max(snapshotLastSeq, recoveredCommit)
+      initialLastSeq   = math.max(snapshotLastSeq, maxLogSeq)
+      _              <- ZIO.foreachDiscard((snapshotLastSeq + 1L) to initialCommitSeq) { seq =>
+                          logState.entries.get(seq) match {
+                            case Some(bytes) =>
+                              ZIO.attempt(StateCommand.parseFrom(bytes)).flatMap(stateMachine.apply).orDie
+                            case None        => ZIO.unit
+                          }
+                        }
+      initialPending  = logState.entries.filter { case (s, _) => s > initialCommitSeq }
       loaded         <- voterStore.load
       // When persistent state already exists, never short-circuit to leader:
       // doing so would skip the election protocol and the persisted term/vote
@@ -556,16 +687,20 @@ object ProtoConsensusEngine {
       initialLeader   = if initialRole == Role.Leader then Some(nodeId) else None
       initialTerm     = if initialRole == Role.Leader then 1L else loaded.term
       initialVotedFor = if initialRole == Role.Leader then None else loaded.votedFor
+      restoredSeq     = initialLastSeq
       stateRef       <- Ref.make(
                           ConsensusState(
                             role = initialRole,
                             term = initialTerm,
                             votedFor = initialVotedFor,
                             leaderId = initialLeader,
-                            lastSeq = persisted.fold(0L)(_.lastSeq),
+                            lastSeq = restoredSeq,
+                            commitSeq = initialCommitSeq,
+                            lastApplied = initialCommitSeq,
                             lastHeartbeatNanos = java.lang.System.nanoTime()
                           )
                         )
+      pendingRef     <- Ref.make(initialPending)
       // If we took the single-node leader shortcut, fsync the bootstrap term
       // immediately so a crash before the first election still leaves us at
       // a term we can compare against on restart.
@@ -573,6 +708,7 @@ object ProtoConsensusEngine {
                           .save(VoterState(initialTerm, initialVotedFor))
                           .when(initialTerm != loaded.term || initialVotedFor != loaded.votedFor)
       persistMutex   <- Semaphore.make(1)
+      logMutex       <- Semaphore.make(1)
       snapshotMutex  <- Semaphore.make(1)
       appliesRef     <- Ref.make(0L)
       peersRef       <- Ref.make(peers)
@@ -582,8 +718,11 @@ object ProtoConsensusEngine {
       peersRef,
       config,
       stateRef,
+      pendingRef,
       voterStore,
+      commandLogStore,
       persistMutex,
+      logMutex,
       snapshotStore,
       snapshotMutex,
       appliesRef

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoDRefGrpcServer.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoDRefGrpcServer.scala
@@ -21,6 +21,8 @@ final class ProtoDRefGrpcServer(
         )
       case ConsensusError.NoLeader            =>
         new StatusException(Status.FAILED_PRECONDITION.withDescription("no-leader:unknown"))
+      case ConsensusError.QuorumLost          =>
+        new StatusException(Status.UNAVAILABLE.withDescription("quorum-lost"))
       case ConsensusError.Serialize(message)  =>
         new StatusException(Status.INTERNAL.withDescription(s"serialize: $message"))
       case ConsensusError.Transport(message)  =>
@@ -56,19 +58,15 @@ final class ProtoDRefGrpcServer(
     context: RequestContext
   ): IO[StatusException, GetElementResponse] =
     for {
-      isLeader <- consensus.isLeader
-      leaderId <- consensus.leaderId
-      response <-
-        if !isLeader then ZIO.fail(mapErr(ConsensusError.NotLeader(leaderId)))
-        else
-          consensus.stateMachine
-            .get(request.name)
-            .mapError { err =>
-              new StatusException(Status.INTERNAL.withDescription(err.getMessage))
-            }
-            .map { value =>
-              GetElementResponse(value.map(com.google.protobuf.ByteString.copyFrom))
-            }
+      _        <- consensus.readIndex.mapError(mapErr)
+      response <- consensus.stateMachine
+                    .get(request.name)
+                    .mapError { err =>
+                      new StatusException(Status.INTERNAL.withDescription(err.getMessage))
+                    }
+                    .map { value =>
+                      GetElementResponse(value.map(com.google.protobuf.ByteString.copyFrom))
+                    }
     } yield response
 
   override def deleteElement(

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/CommandLogStoreSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/CommandLogStoreSpec.scala
@@ -1,0 +1,80 @@
+package io.github.tobia80.dref.raft
+
+import io.github.tobia80.dref.raft.proto.{CommandLogEntry, CommandLogState, CommandLogStore, StateCommands}
+import zio.*
+import zio.test.*
+
+import java.nio.file.{Files, Path}
+
+object CommandLogStoreSpec extends ZIOSpecDefault {
+
+  private def deleteRecursive(path: Path): Unit =
+    if java.nio.file.Files.exists(path) then {
+      if java.nio.file.Files.isDirectory(path) then {
+        val it = java.nio.file.Files.newDirectoryStream(path)
+        try it.forEach(deleteRecursive)
+        finally it.close()
+      }
+      java.nio.file.Files.deleteIfExists(path)
+      ()
+    }
+
+  private val tempDir: ZIO[Scope, Throwable, Path] =
+    ZIO.acquireRelease(
+      ZIO.attemptBlocking(Files.createTempDirectory("command-log-spec"))
+    )(dir => ZIO.attemptBlocking(deleteRecursive(dir)).orDie)
+
+  private def readGoldenHex(name: String): Task[String] =
+    ZIO.attempt {
+      val path = java.nio.file.Paths.get(sys.props.getOrElse("user.dir", "."), "compat", "command_log_vectors.json")
+      val text = Files.readString(path)
+      val pattern = s"""\"name\"\\s*:\\s*\"$name\"[^}]*\"hex\"\\s*:\\s*\"([^\"]*)\"""".r
+      pattern.findFirstMatchIn(text).map(_.group(1)).getOrElse("")
+    }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] = suite("CommandLogStore")(
+    test("load on missing file returns empty") {
+      for {
+        dir   <- tempDir
+        store <- CommandLogStore.file(dir)
+        state <- store.load
+      } yield assertTrue(state == CommandLogState.empty)
+    },
+    test("append and load round-trip") {
+      for {
+        dir   <- tempDir
+        store <- CommandLogStore.file(dir)
+        cmd    = StateCommands.setElement("k", Array[Byte](1, 2), None).toByteArray
+        _     <- store.append(1L, cmd)
+        _     <- store.setCommitSeq(1L)
+        state <- store.load
+      } yield assertTrue(
+        state.commitSeq == 1L,
+        state.entries.get(1L).exists(_.sameElements(cmd))
+      )
+    },
+    test("truncateThrough drops committed prefix") {
+      for {
+        dir   <- tempDir
+        store <- CommandLogStore.file(dir)
+        _     <- store.append(1L, Array[Byte](1))
+        _     <- store.append(2L, Array[Byte](2))
+        _     <- store.setCommitSeq(2L)
+        _     <- store.truncateThrough(1L)
+        state <- store.load
+      } yield assertTrue(
+        state.commitSeq == 1L,
+        state.entries.get(1L).isEmpty,
+        state.entries.get(2L).exists(_.sameElements(Array[Byte](2)))
+      )
+    },
+    test("on-disk bytes match cross-language golden vectors") {
+      val cmd = StateCommands.setElement("my-key", Array[Byte](1, 2, 3), Some(1700000000L)).toByteArray
+      val encoded = CommandLogStore.encodeForTest(CommandLogEntry(1L, cmd), commitSeq = 0L)
+      val hex = encoded.map(b => f"$b%02x").mkString
+      for {
+        expected <- readGoldenHex("single_set_element_record")
+      } yield assertTrue(hex == expected, hex.nonEmpty)
+    }
+  ) @@ TestAspect.sequential
+}

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/ProtoConsensusPersistenceSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/ProtoConsensusPersistenceSpec.scala
@@ -100,7 +100,7 @@ object ProtoConsensusPersistenceSpec extends ZIOSpecDefault {
       for {
         dir       <- tempDir
         engine    <- makeEngine(Some(dir))
-        _         <- engine.handleAppendEntries(leaderId = "leader-x", term = 12L, seq = 0L, command = Array.emptyByteArray)
+        _         <- engine.handleAppendEntries(leaderId = "leader-x", term = 12L, seq = 0L, command = Array.emptyByteArray, commitSeq = 0L)
         verifier  <- VoterStateStore.file(dir)
         persisted <- verifier.load
       } yield assertTrue(
@@ -179,7 +179,7 @@ object ProtoConsensusPersistenceSpec extends ZIOSpecDefault {
         dir       <- tempDir
         engine    <- makeEngine(Some(dir))
         // Move into Follower at term=2 via AppendEntries.
-        _         <- engine.handleAppendEntries(leaderId = "x", term = 2L, seq = 0L, command = Array.emptyByteArray)
+        _         <- engine.handleAppendEntries(leaderId = "x", term = 2L, seq = 0L, command = Array.emptyByteArray, commitSeq = 0L)
         result    <- engine.handlePreVote(candidateId = "candidate-x", term = 99L, lastSeq = 0L)
         verifier  <- VoterStateStore.file(dir)
         persisted <- verifier.load
@@ -192,7 +192,7 @@ object ProtoConsensusPersistenceSpec extends ZIOSpecDefault {
     test("handlePreVote refuses when a leader heartbeat is recent") {
       for {
         engine <- makeEngine(None)
-        _      <- engine.handleHeartbeat("leader-x", term = 1L)
+        _      <- engine.handleHeartbeat("leader-x", term = 1L, commitSeq = 0L)
         result <- engine.handlePreVote(candidateId = "disruptor", term = 50L, lastSeq = 0L)
       } yield assertTrue(
         !result._1,             // refused: leader was fresh
@@ -202,7 +202,7 @@ object ProtoConsensusPersistenceSpec extends ZIOSpecDefault {
     test("handlePreVote refuses when proposed term is not strictly greater") {
       for {
         engine <- makeEngine(None)
-        _      <- engine.handleAppendEntries(leaderId = "x", term = 5L, seq = 0L, command = Array.emptyByteArray)
+        _      <- engine.handleAppendEntries(leaderId = "x", term = 5L, seq = 0L, command = Array.emptyByteArray, commitSeq = 0L)
         equal  <- engine.handlePreVote(candidateId = "c", term = 5L, lastSeq = 0L)
         lower  <- engine.handlePreVote(candidateId = "c", term = 4L, lastSeq = 0L)
       } yield assertTrue(!equal._1, !lower._1)
@@ -292,6 +292,19 @@ object ProtoConsensusPersistenceSpec extends ZIOSpecDefault {
       } yield assertTrue(
         loaded.flatten.exists(_.entries.exists(_.key == "auto"))
       )
+    },
+    test("restarted engine replays committed command log entries not yet snapshotted") {
+      for {
+        dir   <- tempDir
+        _     <- ZIO.scoped {
+                   makeEngineWithMachine(Some(dir), snapshotEvery = 0).flatMap { case (_, engine) =>
+                     engine.submit(setElement("from-wal", Array[Byte](9))).either
+                   }
+                 }
+        pair  <- makeEngineWithMachine(Some(dir), snapshotEvery = 0)
+        (sm2, _) = pair
+        value <- sm2.get("from-wal")
+      } yield assertTrue(value.exists(_.toSeq == Seq[Byte](9)))
     },
     test("snapshotEvery=0 disables automatic snapshots") {
       for {

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/ProtoRaftDRefSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/ProtoRaftDRefSpec.scala
@@ -127,16 +127,37 @@ object ProtoRaftDRefSpec extends ZIOSpecDefault {
         leaders <- ZIO.foreach(nodes)(_.isLeader)
       } yield assertTrue(leaders.count(identity) == 1)
     },
-    test("write through any node propagates to all nodes") {
+    test("write through any node propagates to all nodes without extra delay") {
       for {
         nodes  <- startCluster(3)
         writer <- ZIO
                     .foreach(nodes)(n => n.isLeader.map(b => (n, b)))
                     .map(_.find(!_._2).map(_._1).getOrElse(nodes.head))
         _      <- writer.setElement("propagated", "yes".getBytes, None)
-        _      <- ZIO.sleep(300.millis)
         values <- ZIO.foreach(nodes)(_.getElement("propagated"))
       } yield assertTrue(values.forall(_.exists(_.sameElements("yes".getBytes))))
+    },
+    test("write fails when a quorum is unreachable") {
+      for {
+        ports  <- ZIO.foreach(List.fill(3)(()))(_ => freePort)
+        scopes <- ZIO.foreach((0 until 3).toList)(_ => Scope.make)
+        start   = (idx: Int) =>
+                    scopes(idx).extend[Any](
+                      ProtoRaftDRefContext.start(makeClusterConfig(ports, idx, s"node-$idx"), 2.seconds)
+                    )
+        nodes  <- ZIO.foreach((0 until 3).toList)(start)
+        _      <- ZIO.addFinalizer(ZIO.foreachDiscard(scopes)(_.close(Exit.unit)))
+        _      <- waitForSingleLeader(nodes)
+        _      <- waitForStableLeader(nodes)
+        leaderIdx <- ZIO
+                       .foreach(nodes.zipWithIndex) { case (n, i) => n.isLeader.map(i -> _) }
+                       .map(_.collectFirst { case (i, true) => i }.get)
+        followerIdxs = (0 until 3).filter(_ != leaderIdx).toList
+        _      <- ZIO.foreachDiscard(followerIdxs)(idx => scopes(idx).close(Exit.unit))
+        _      <- ZIO.sleep(100.millis)
+        // With only the leader alive, a three-node cluster cannot reach a majority.
+        result <- nodes(leaderIdx).setElement("quorum-key", "nope".getBytes, None).either
+      } yield assertTrue(result.isLeft)
     },
     test("on_change_stream observes replicated writes") {
       for {

--- a/proto/dref_consensus.proto
+++ b/proto/dref_consensus.proto
@@ -26,6 +26,9 @@ message AppendEntriesRequest {
   bytes command = 3;
   // Monotonic sequence number for ordering and deduplication.
   uint64 seq = 4;
+  // Highest sequence known committed on a majority. Followers apply stored
+  // entries up to this index but never beyond.
+  uint64 commit_seq = 5;
 }
 
 message AppendEntriesResponse {
@@ -35,6 +38,18 @@ message AppendEntriesResponse {
 
 message HeartbeatRequest {
   string leader_id = 1;
+  uint64 term = 2;
+  // Propagates the leader's commit index so followers apply pending entries.
+  uint64 commit_seq = 3;
+}
+
+message ReadIndexRequest {
+  string leader_id = 1;
+  uint64 term = 2;
+}
+
+message ReadIndexResponse {
+  bool granted = 1;
   uint64 term = 2;
 }
 
@@ -88,6 +103,7 @@ message InstallSnapshotResponse {
 service DRefConsensus {
   rpc AppendEntries(AppendEntriesRequest) returns (AppendEntriesResponse) {}
   rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse) {}
+  rpc ReadIndex(ReadIndexRequest) returns (ReadIndexResponse) {}
   rpc RequestVote(VoteRequest) returns (VoteResponse) {}
   rpc RequestPreVote(PreVoteRequest) returns (PreVoteResponse) {}
   rpc InstallSnapshot(InstallSnapshotRequest) returns (InstallSnapshotResponse) {}

--- a/rust/dref-raft/src/command_log_store.rs
+++ b/rust/dref-raft/src/command_log_store.rs
@@ -1,0 +1,322 @@
+//! Append-only command log persisted before replication acks.
+//!
+//! Wire format matches Scala [`CommandLogStore`](../../dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/CommandLogStore.scala).
+
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+const MAGIC: u32 = 0x4452_464c; // "DRFL"
+const VERSION: u8 = 1;
+const FILE_NAME: &str = "command-log";
+const TMP_SUFFIX: &str = ".tmp";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandLogEntry {
+    pub seq: u64,
+    pub command: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandLogState {
+    pub commit_seq: u64,
+    pub entries: BTreeMap<u64, Vec<u8>>,
+}
+
+impl CommandLogState {
+    pub fn empty() -> Self {
+        Self {
+            commit_seq: 0,
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommandLogError {
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+    #[error("command-log file truncated")]
+    Truncated,
+    #[error("command-log magic mismatch: expected 0x{MAGIC:08x} got 0x{got:08x}")]
+    BadMagic { got: u32 },
+    #[error("command-log version {version} not supported")]
+    BadVersion { version: u8 },
+    #[error("command-log negative command length at seq {seq}")]
+    NegativeLength { seq: u64 },
+}
+
+pub trait CommandLogStore: Send + Sync {
+    fn load(&self) -> Result<CommandLogState, CommandLogError>;
+    fn append(&self, seq: u64, command: &[u8]) -> Result<(), CommandLogError>;
+    fn set_commit_seq(&self, commit_seq: u64) -> Result<(), CommandLogError>;
+    fn truncate_through(&self, through_seq: u64) -> Result<(), CommandLogError>;
+}
+
+pub struct NoopCommandLogStore;
+
+impl CommandLogStore for NoopCommandLogStore {
+    fn load(&self) -> Result<CommandLogState, CommandLogError> {
+        Ok(CommandLogState::empty())
+    }
+
+    fn append(&self, _seq: u64, _command: &[u8]) -> Result<(), CommandLogError> {
+        Ok(())
+    }
+
+    fn set_commit_seq(&self, _commit_seq: u64) -> Result<(), CommandLogError> {
+        Ok(())
+    }
+
+    fn truncate_through(&self, _through_seq: u64) -> Result<(), CommandLogError> {
+        Ok(())
+    }
+}
+
+pub struct FileCommandLogStore {
+    dir: PathBuf,
+}
+
+impl FileCommandLogStore {
+    pub fn open(dir: impl AsRef<Path>) -> Result<Self, CommandLogError> {
+        let dir = dir.as_ref().to_path_buf();
+        fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+
+    fn target(&self) -> PathBuf {
+        self.dir.join(FILE_NAME)
+    }
+
+    fn tmp(&self) -> PathBuf {
+        self.dir.join(format!("{FILE_NAME}{TMP_SUFFIX}"))
+    }
+
+    fn ensure_header(&self) -> Result<(), CommandLogError> {
+        let path = self.target();
+        if path.exists() {
+            return Ok(());
+        }
+        let mut file = File::create(&path)?;
+        write_header(&mut file, 0)?;
+        file.sync_all()?;
+        Ok(())
+    }
+
+    fn rewrite(&self, commit_seq: u64, entries: &BTreeMap<u64, Vec<u8>>) -> Result<(), CommandLogError> {
+        let tmp = self.tmp();
+        {
+            let mut file = File::create(&tmp)?;
+            write_header(&mut file, commit_seq)?;
+            for (seq, command) in entries {
+                write_record(&mut file, *seq, command)?;
+            }
+            file.sync_all()?;
+        }
+        fs::rename(&tmp, self.target())?;
+        Ok(())
+    }
+}
+
+impl CommandLogStore for FileCommandLogStore {
+    fn load(&self) -> Result<CommandLogState, CommandLogError> {
+        let path = self.target();
+        if !path.exists() {
+            return Ok(CommandLogState::empty());
+        }
+        let mut file = File::open(&path)?;
+        read_log(&mut file)
+    }
+
+    fn append(&self, seq: u64, command: &[u8]) -> Result<(), CommandLogError> {
+        self.ensure_header()?;
+        let mut file = OpenOptions::new().append(true).open(self.target())?;
+        write_record(&mut file, seq, command)?;
+        file.sync_all()?;
+        Ok(())
+    }
+
+    fn set_commit_seq(&self, commit_seq: u64) -> Result<(), CommandLogError> {
+        self.ensure_header()?;
+        let mut file = OpenOptions::new().write(true).open(self.target())?;
+        file.seek(SeekFrom::Start(5))?;
+        write_u64_be(&mut file, commit_seq)?;
+        file.sync_all()?;
+        Ok(())
+    }
+
+    fn truncate_through(&self, through_seq: u64) -> Result<(), CommandLogError> {
+        let path = self.target();
+        if !path.exists() {
+            return Ok(());
+        }
+        let state = {
+            let mut file = File::open(&path)?;
+            read_log(&mut file)?
+        };
+        let kept: BTreeMap<u64, Vec<u8>> = state
+            .entries
+            .into_iter()
+            .filter(|(seq, _)| *seq > through_seq)
+            .collect();
+        let new_commit = state.commit_seq.min(through_seq);
+        self.rewrite(new_commit, &kept)
+    }
+}
+
+fn read_log<R: Read>(mut r: R) -> Result<CommandLogState, CommandLogError> {
+    let magic = read_u32_be(&mut r)?;
+    if magic != MAGIC {
+        return Err(CommandLogError::BadMagic { got: magic });
+    }
+    let version = read_u8(&mut r)?;
+    if version != VERSION {
+        return Err(CommandLogError::BadVersion { version });
+    }
+    let commit_seq = read_u64_be(&mut r)?;
+    let mut entries = BTreeMap::new();
+    loop {
+        match read_u64_be(&mut r) {
+            Ok(seq) => {
+                let len = read_i32_be(&mut r)?;
+                if len < 0 {
+                    return Err(CommandLogError::NegativeLength { seq });
+                }
+                let len = len as usize;
+                let mut command = vec![0u8; len];
+                r.read_exact(&mut command).map_err(map_eof)?;
+                entries.insert(seq, command);
+            }
+            Err(CommandLogError::Truncated) => break,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(CommandLogState { commit_seq, entries })
+}
+
+fn write_header<W: Write>(w: &mut W, commit_seq: u64) -> Result<(), CommandLogError> {
+    write_u32_be(w, MAGIC)?;
+    write_u8(w, VERSION)?;
+    write_u64_be(w, commit_seq)?;
+    Ok(())
+}
+
+fn write_record<W: Write>(w: &mut W, seq: u64, command: &[u8]) -> Result<(), CommandLogError> {
+    write_u64_be(w, seq)?;
+    write_i32_be(w, command.len() as i32)?;
+    w.write_all(command).map_err(CommandLogError::Io)?;
+    Ok(())
+}
+
+fn read_u8(r: &mut impl Read) -> Result<u8, CommandLogError> {
+    let mut b = [0u8; 1];
+    r.read_exact(&mut b).map_err(map_eof)?;
+    Ok(b[0])
+}
+
+fn read_u32_be(r: &mut impl Read) -> Result<u32, CommandLogError> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b).map_err(map_eof)?;
+    Ok(u32::from_be_bytes(b))
+}
+
+fn read_i32_be(r: &mut impl Read) -> Result<i32, CommandLogError> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b).map_err(map_eof)?;
+    Ok(i32::from_be_bytes(b))
+}
+
+fn read_u64_be(r: &mut impl Read) -> Result<u64, CommandLogError> {
+    let mut b = [0u8; 8];
+    r.read_exact(&mut b).map_err(map_eof)?;
+    Ok(u64::from_be_bytes(b))
+}
+
+fn write_u8(w: &mut impl Write, v: u8) -> Result<(), CommandLogError> {
+    w.write_all(&[v]).map_err(CommandLogError::Io)
+}
+
+fn write_u32_be(w: &mut impl Write, v: u32) -> Result<(), CommandLogError> {
+    w.write_all(&v.to_be_bytes()).map_err(CommandLogError::Io)
+}
+
+fn write_i32_be(w: &mut impl Write, v: i32) -> Result<(), CommandLogError> {
+    w.write_all(&v.to_be_bytes()).map_err(CommandLogError::Io)
+}
+
+fn write_u64_be(w: &mut impl Write, v: u64) -> Result<(), CommandLogError> {
+    w.write_all(&v.to_be_bytes()).map_err(CommandLogError::Io)
+}
+
+fn map_eof(e: io::Error) -> CommandLogError {
+    if e.kind() == io::ErrorKind::UnexpectedEof {
+        CommandLogError::Truncated
+    } else {
+        CommandLogError::Io(e)
+    }
+}
+
+/// Encode header + one record for golden-vector tests.
+pub fn encode_for_test(entry: &CommandLogEntry, commit_seq: u64) -> Result<Vec<u8>, CommandLogError> {
+    let mut buf = Vec::new();
+    write_header(&mut buf, commit_seq)?;
+    write_record(&mut buf, entry.seq, &entry.command)?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "dref-command-log-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn load_missing_returns_empty() {
+        let dir = temp_dir("missing");
+        let _ = fs::remove_dir_all(&dir);
+        let store = FileCommandLogStore::open(&dir).unwrap();
+        assert_eq!(store.load().unwrap(), CommandLogState::empty());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn append_and_load_round_trip() {
+        let dir = temp_dir("round-trip");
+        let _ = fs::remove_dir_all(&dir);
+        let store = FileCommandLogStore::open(&dir).unwrap();
+        store.append(1, &[1, 2, 3]).unwrap();
+        store.append(2, &[4]).unwrap();
+        store.set_commit_seq(1).unwrap();
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded.commit_seq, 1);
+        assert_eq!(loaded.entries.get(&1).map(|v| v.as_slice()), Some(&[1, 2, 3][..]));
+        assert_eq!(loaded.entries.get(&2).map(|v| v.as_slice()), Some(&[4][..]));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn truncate_through_drops_committed_prefix() {
+        let dir = temp_dir("truncate");
+        let _ = fs::remove_dir_all(&dir);
+        let store = FileCommandLogStore::open(&dir).unwrap();
+        store.append(1, &[1]).unwrap();
+        store.append(2, &[2]).unwrap();
+        store.set_commit_seq(2).unwrap();
+        store.truncate_through(1).unwrap();
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded.commit_seq, 1);
+        assert!(!loaded.entries.contains_key(&1));
+        assert_eq!(loaded.entries.get(&2).map(|v| v.as_slice()), Some(&[2][..]));
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/rust/dref-raft/src/consensus.rs
+++ b/rust/dref-raft/src/consensus.rs
@@ -1,32 +1,22 @@
-//! Simplified Raft-style consensus.
+//! Raft-style consensus with quorum commit and linearizable reads.
 //!
-//! This is the "simple in-memory consensus wrapper" called out as acceptable
-//! in the task spec when openraft's API turns out to be too involved for the
-//! scope of this port. It is intentionally a small fraction of what
-//! production Raft does — but it nails the things `dref-raft` actually
-//! needs:
+//! This is a pragmatic in-memory Raft implementation for replicated locks
+//! and short-lived shared state. It provides:
 //!
-//! - a single leader is elected via term-based voting,
-//! - all writes go through the leader,
-//! - the leader replicates each committed command to every reachable
-//!   follower via gRPC `AppendEntries`,
-//! - followers detect leader loss via heartbeat timeout and start a new
-//!   election,
-//! - a new leader replays its snapshot to followers that fell behind.
+//! - term-based leader election with PreVote,
+//! - quorum-committed writes (ack only after majority replication),
+//! - ReadIndex-style linearizable reads on the leader,
+//! - snapshot catch-up for lagging followers.
 //!
-//! Things this does NOT do (relative to "real" Raft):
-//! - no persistent log: commands are applied in memory only,
-//! - no log truncation on conflict (we only ever replicate from the
-//!   current leader's state, snapshot-style),
-//! - membership is refreshed when an [`IpProvider`] is configured (DNS /
-//!   k8s polling updates peers via [`Consensus::sync_peers`]).
-//!
-//! These limits are fine for the role this crate plays: replicated locks
-//! and short-lived shared state across a fixed-size cluster. They also map
-//! cleanly onto a future swap to a real Raft implementation: the public
-//! [`Consensus`] API doesn't expose anything that would change.
+//! Relative to full Raft (Ongaro §5–§7):
+//! - append-only command log (`command-log`, magic DRFL) fsync'd before
+//!   replication acks; truncated when snapshots catch up,
+//! - no log truncation on conflict (strict monotonic `seq` + snapshot
+//!   install for divergence),
+//! - membership refreshed via [`Consensus::sync_peers`] when an
+//!   [`IpProvider`] is configured.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -36,11 +26,14 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::time::{sleep, Instant};
 use tracing::{debug, info, warn};
 
+use crate::command_log_store::{
+    CommandLogStore, FileCommandLogStore, NoopCommandLogStore,
+};
 use crate::config::{NodeEndpoint, RaftConfig};
 use crate::proto::dref_consensus::d_ref_consensus_client::DRefConsensusClient;
 use crate::proto::dref_consensus::{
     AppendEntriesRequest, ClusterSnapshot, HeartbeatRequest, InstallSnapshotRequest,
-    PreVoteRequest, VoteRequest,
+    PreVoteRequest, ReadIndexRequest, VoteRequest,
 };
 use crate::state_command::{self, StateCommand};
 use crate::state_machine::{ApplyResult, StateMachine};
@@ -69,6 +62,8 @@ pub enum ConsensusError {
     NotLeader { leader_id: Option<String> },
     #[error("no leader is currently elected")]
     NoLeader,
+    #[error("write could not be replicated to a quorum")]
+    QuorumLost,
     #[error("serialization failure: {0}")]
     Serialize(String),
     #[error("transport failure: {0}")]
@@ -122,10 +117,12 @@ struct ConsensusState {
     voted_for: Option<String>,
     /// Last known leader id (informational; used by `NotLeader` errors).
     leader_id: Option<String>,
-    /// Monotonic sequence number of the last committed command. Followers
-    /// reject AppendEntries with an out-of-order seq, which lets a new
-    /// leader notice it needs to ship a snapshot.
+    /// Monotonic sequence number of the last replicated command.
     last_seq: u64,
+    /// Highest sequence known committed on a majority.
+    commit_seq: u64,
+    /// Highest sequence applied to the state machine.
+    last_applied: u64,
     /// When we last heard from the leader. Used to drive election timeout.
     last_heartbeat: Instant,
 }
@@ -137,9 +134,12 @@ pub struct Consensus {
     peers: Arc<RwLock<HashMap<String, Arc<PeerConn>>>>,
     pub state_machine: StateMachine,
     state: Arc<RwLock<ConsensusState>>,
+    pending: Arc<RwLock<BTreeMap<u64, Vec<u8>>>>,
+    command_log_store: StdArc<dyn CommandLogStore>,
     config: RaftConfig,
     voter_store: StdArc<dyn VoterStateStore>,
     persist_mutex: Arc<Mutex<()>>,
+    log_mutex: Arc<Mutex<()>>,
     snapshot_store: StdArc<dyn StateMachineSnapshotStore>,
     snapshot_mutex: Arc<Mutex<()>>,
     applies_since_snapshot: Arc<std::sync::atomic::AtomicU64>,
@@ -165,12 +165,38 @@ impl Consensus {
             ),
             None => StdArc::new(NoopStateMachineSnapshotStore),
         };
+        let command_log_store: StdArc<dyn CommandLogStore> = match &config.storage_dir {
+            Some(dir) => {
+                StdArc::new(FileCommandLogStore::open(dir).expect("create command-log storage directory"))
+            }
+            None => StdArc::new(NoopCommandLogStore),
+        };
         let persisted = snapshot_store
             .load()
             .expect("load persisted state-machine snapshot");
         if let Some(snapshot) = persisted.clone() {
             state_machine.install_snapshot(snapshot).await;
         }
+        let snapshot_last_seq = persisted.as_ref().map(|s| s.last_seq).unwrap_or(0);
+        let log_state = command_log_store
+            .load()
+            .expect("load persisted command log");
+        let max_log_seq = log_state.entries.keys().max().copied().unwrap_or(0);
+        let recovered_commit = log_state.commit_seq.min(max_log_seq);
+        let initial_commit_seq = snapshot_last_seq.max(recovered_commit);
+        let initial_last_seq = snapshot_last_seq.max(max_log_seq);
+        for seq in (snapshot_last_seq + 1)..=initial_commit_seq {
+            if let Some(bytes) = log_state.entries.get(&seq) {
+                if let Ok(cmd) = state_command::decode(bytes) {
+                    state_machine.apply(cmd).await;
+                }
+            }
+        }
+        let initial_pending: BTreeMap<u64, Vec<u8>> = log_state
+            .entries
+            .into_iter()
+            .filter(|(seq, _)| *seq > initial_commit_seq)
+            .collect();
         let loaded = voter_store.load().expect("load persisted voter state");
         let mut peers = HashMap::new();
         for ep in &config.initial_endpoints {
@@ -218,16 +244,29 @@ impl Consensus {
                 term: initial_term,
                 voted_for: initial_voted_for,
                 leader_id,
-                last_seq: persisted.as_ref().map(|s| s.last_seq).unwrap_or(0),
+                last_seq: initial_last_seq,
+                commit_seq: initial_commit_seq,
+                last_applied: initial_commit_seq,
                 last_heartbeat: Instant::now(),
             })),
+            pending: Arc::new(RwLock::new(initial_pending)),
+            command_log_store,
             config,
             voter_store,
             persist_mutex: Arc::new(Mutex::new(())),
+            log_mutex: Arc::new(Mutex::new(())),
             snapshot_store,
             snapshot_mutex: Arc::new(Mutex::new(())),
             applies_since_snapshot: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
+    }
+
+    async fn with_command_log<F, R>(&self, op: F) -> R
+    where
+        F: FnOnce(&dyn CommandLogStore) -> R,
+    {
+        let _guard = self.log_mutex.lock().await;
+        op(self.command_log_store.as_ref())
     }
 
     /// Align the consensus peer map with the current discovery snapshot.
@@ -258,6 +297,8 @@ impl Consensus {
             voted_for: st.voted_for.clone(),
             leader_id: st.leader_id.clone(),
             last_seq: st.last_seq,
+            commit_seq: st.commit_seq,
+            last_applied: st.last_applied,
             last_heartbeat: st.last_heartbeat,
         };
         let (result, next) = f(current);
@@ -306,12 +347,18 @@ impl Consensus {
     /// triggers don't both write — the second waits, then takes a fresh snapshot itself.
     async fn persist_snapshot_now(&self) -> Result<(), String> {
         let _guard = self.snapshot_mutex.lock().await;
+        let commit_seq = self.state.read().await.commit_seq;
         let last_seq = self.state.read().await.last_seq;
         let mut snapshot = self.state_machine.take_snapshot().await;
         snapshot.last_seq = last_seq;
         self.snapshot_store
             .save(&snapshot)
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        self.with_command_log(|log| {
+            log.truncate_through(commit_seq)
+                .map_err(|e| e.to_string())
+        })
+        .await
     }
 
     /// Force a snapshot persist now. Exposed for tests and graceful shutdown.
@@ -375,42 +422,55 @@ impl Consensus {
             .map(|p| p.endpoint.address.clone())
     }
 
-    /// Submit a write command. Must be called on the leader; returns
-    /// [`ConsensusError::NotLeader`] otherwise.
-    ///
-    /// On the leader we (1) apply locally, (2) bump `last_seq`, (3) fan
-    /// out to followers in parallel. We do NOT wait for a quorum — every
-    /// follower is "best effort" replication. This is the main divergence
-    /// from real Raft and the reason we call out the simplification at the
-    /// top of this file.
-    pub async fn submit(&self, cmd: StateCommand) -> Result<ApplyResult, ConsensusError> {
-        let (term, seq) = {
-            let mut st = self.state.write().await;
-            if st.role != Role::Leader {
-                return Err(ConsensusError::NotLeader {
-                    leader_id: st.leader_id.clone(),
-                });
-            }
-            st.last_seq += 1;
-            (st.term, st.last_seq)
-        };
-
-        let bytes =
-            state_command::encode(&cmd).map_err(|e| ConsensusError::Serialize(e.to_string()))?;
-        let result = self.state_machine.apply(cmd).await;
-        self.note_applied().await;
-
-        // Fire-and-forget replication. Followers can fall behind; the
-        // periodic snapshot-install during reconnection brings them back.
-        self.replicate(term, seq, bytes).await;
-
-        Ok(result)
+    fn quorum_needed(cluster_size: usize) -> usize {
+        cluster_size / 2 + 1
     }
 
-    /// Replicate one entry to all peers in parallel. Errors are logged but
-    /// don't fail the submit — see top-of-file note on the simplified
-    /// quorum model.
-    async fn replicate(&self, term: u64, seq: u64, command: Vec<u8>) {
+    async fn apply_committed(&self, commit_seq: u64) {
+        let start = {
+            let st = self.state.read().await;
+            if commit_seq <= st.commit_seq {
+                return;
+            }
+            st.last_applied + 1
+        };
+        for seq in start..=commit_seq {
+            let bytes = {
+                let pending = self.pending.read().await;
+                pending.get(&seq).cloned()
+            };
+            let Some(bytes) = bytes else {
+                warn!(seq, commit_seq, "missing pending entry while applying commit");
+                return;
+            };
+            match state_command::decode(&bytes) {
+                Ok(cmd) => {
+                    self.state_machine.apply(cmd).await;
+                    self.note_applied().await;
+                    {
+                        let mut st = self.state.write().await;
+                        st.last_applied = seq;
+                    }
+                    self.pending.write().await.remove(&seq);
+                }
+                Err(e) => {
+                    warn!(error = ?e, seq, "failed to decode pending entry");
+                    return;
+                }
+            }
+        }
+        {
+            let mut st = self.state.write().await;
+            if commit_seq > st.commit_seq {
+                st.commit_seq = commit_seq;
+            }
+        }
+        let _ = self
+            .with_command_log(|log| log.set_commit_seq(commit_seq))
+            .await;
+    }
+
+    async fn propagate_commit_seq(&self, commit_seq: u64, term: u64) {
         let peers: Vec<(String, Arc<PeerConn>)> = self
             .peers
             .read()
@@ -418,13 +478,180 @@ impl Consensus {
             .iter()
             .map(|(id, p)| (id.clone(), Arc::clone(p)))
             .collect();
-        let mut tasks = Vec::new();
+        let mut futs = Vec::new();
+        for (id, peer) in peers {
+            let leader_id = self.node_id.clone();
+            let timeout = self.config.connection_timeout;
+            let this = self.clone();
+            futs.push(tokio::spawn(async move {
+                match peer.client(timeout).await {
+                    Ok(mut client) => {
+                        let req = HeartbeatRequest {
+                            leader_id,
+                            term,
+                            commit_seq,
+                        };
+                        match client.heartbeat(req).await {
+                            Ok(resp) => {
+                                this.step_down_if_stale(resp.into_inner().term).await;
+                            }
+                            Err(e) => {
+                                debug!(peer = %id, error = ?e, "commit heartbeat failed");
+                                peer.reset().await;
+                            }
+                        }
+                    }
+                    Err(e) => debug!(peer = %id, error = ?e, "no client for commit heartbeat"),
+                }
+            }));
+        }
+        for fut in futs {
+            let _ = fut.await;
+        }
+    }
+
+    /// Submit a write command. Must be called on the leader; returns
+    /// [`ConsensusError::NotLeader`] otherwise. The write is acknowledged
+    /// only after a quorum of nodes has stored the entry.
+    pub async fn submit(&self, cmd: StateCommand) -> Result<ApplyResult, ConsensusError> {
+        let (term, seq, commit_seq_before) = {
+            let mut st = self.state.write().await;
+            if st.role != Role::Leader {
+                return Err(ConsensusError::NotLeader {
+                    leader_id: st.leader_id.clone(),
+                });
+            }
+            st.last_seq += 1;
+            (st.term, st.last_seq, st.commit_seq)
+        };
+
+        let bytes =
+            state_command::encode(&cmd).map_err(|e| ConsensusError::Serialize(e.to_string()))?;
+        self.with_command_log(|log| {
+            log.append(seq, &bytes)
+                .map_err(|e| ConsensusError::Serialize(e.to_string()))
+        })
+        .await?;
+        let peers: Vec<(String, Arc<PeerConn>)> = self
+            .peers
+            .read()
+            .await
+            .iter()
+            .map(|(id, p)| (id.clone(), Arc::clone(p)))
+            .collect();
+        let needed = Self::quorum_needed(peers.len() + 1);
+        let follower_acks = self
+            .replicate_for_quorum(term, seq, bytes, commit_seq_before, peers)
+            .await;
+        let total_acks = 1 + follower_acks;
+        if total_acks < needed {
+            let _ = self
+                .with_command_log(|log| log.truncate_through(seq - 1))
+                .await;
+            let mut st = self.state.write().await;
+            st.last_seq = seq - 1;
+            return Err(ConsensusError::QuorumLost);
+        }
+        if !self.is_leader().await {
+            return Err(ConsensusError::NotLeader {
+                leader_id: self.leader_id().await,
+            });
+        }
+
+        let result = self.state_machine.apply(cmd).await;
+        self.note_applied().await;
+        {
+            let mut st = self.state.write().await;
+            st.commit_seq = seq;
+            st.last_applied = seq;
+        }
+        let _ = self
+            .with_command_log(|log| log.set_commit_seq(seq))
+            .await;
+        self.propagate_commit_seq(seq, term).await;
+        Ok(result)
+    }
+
+    /// Confirm leadership with a quorum before serving a linearizable read.
+    pub async fn read_index(&self) -> Result<(), ConsensusError> {
+        let (term, leader_id, commit_seq, last_applied) = {
+            let st = self.state.read().await;
+            if st.role != Role::Leader {
+                return Err(ConsensusError::NotLeader {
+                    leader_id: st.leader_id.clone(),
+                });
+            }
+            (
+                st.term,
+                st.leader_id.clone(),
+                st.commit_seq,
+                st.last_applied,
+            )
+        };
+
+        let peers: Vec<(String, Arc<PeerConn>)> = self
+            .peers
+            .read()
+            .await
+            .iter()
+            .map(|(id, p)| (id.clone(), Arc::clone(p)))
+            .collect();
+        let needed = Self::quorum_needed(peers.len() + 1);
+        let mut grants: usize = 1;
+        let mut futs = Vec::new();
+        for (id, peer) in peers {
+            let leader_id = self.node_id.clone();
+            let timeout = self.config.connection_timeout;
+            futs.push(tokio::spawn(async move {
+                let mut client = peer.client(timeout).await.ok()?;
+                let req = ReadIndexRequest {
+                    leader_id,
+                    term,
+                };
+                match client.read_index(req).await {
+                    Ok(resp) => Some((id, resp.into_inner())),
+                    Err(e) => {
+                        debug!(peer = %id, error = ?e, "read-index request failed");
+                        None
+                    }
+                }
+            }));
+        }
+        for fut in futs {
+            if let Ok(Some((_id, resp))) = fut.await {
+                if resp.term > term {
+                    self.step_down_if_stale(resp.term).await;
+                    return Err(ConsensusError::NotLeader { leader_id: None });
+                }
+                if resp.granted {
+                    grants += 1;
+                }
+            }
+        }
+        if grants < needed {
+            return Err(ConsensusError::NotLeader { leader_id });
+        }
+        if last_applied < commit_seq {
+            return Err(ConsensusError::NotLeader { leader_id: None });
+        }
+        Ok(())
+    }
+
+    async fn replicate_for_quorum(
+        &self,
+        term: u64,
+        seq: u64,
+        command: Vec<u8>,
+        commit_seq: u64,
+        peers: Vec<(String, Arc<PeerConn>)>,
+    ) -> usize {
+        let mut futs = Vec::new();
         for (id, peer) in peers {
             let command = command.clone();
             let leader_id = self.node_id.clone();
             let timeout = self.config.connection_timeout;
             let this = self.clone();
-            tasks.push(tokio::spawn(async move {
+            futs.push(tokio::spawn(async move {
                 match peer.client(timeout).await {
                     Ok(mut client) => {
                         let req = AppendEntriesRequest {
@@ -432,36 +659,38 @@ impl Consensus {
                             term,
                             command,
                             seq,
+                            commit_seq,
                         };
                         match client.append_entries(req).await {
                             Ok(resp) => {
                                 let resp = resp.into_inner();
                                 this.step_down_if_stale(resp.term).await;
-                                // A follower whose last_seq diverges from
-                                // ours rejects with success=false; without a
-                                // catch-up the strict seq check keeps
-                                // refusing every subsequent entry until a new
-                                // election. Push a snapshot to bring them in
-                                // sync as long as we're still leader at this
-                                // term.
                                 if !resp.success && resp.term <= term {
                                     this.send_snapshot_to(&id, &peer).await;
                                 }
+                                resp.success
                             }
                             Err(e) => {
                                 debug!(peer = %id, error = ?e, "AppendEntries failed");
                                 peer.reset().await;
+                                false
                             }
                         }
                     }
                     Err(e) => {
                         debug!(peer = %id, error = ?e, "could not build client");
+                        false
                     }
                 }
             }));
         }
-        // Don't await; tasks finish on their own.
-        drop(tasks);
+        let mut acks = 0usize;
+        for fut in futs {
+            if let Ok(true) = fut.await {
+                acks += 1;
+            }
+        }
+        acks
     }
 
     async fn send_snapshot_to(&self, peer_id: &str, peer: &Arc<PeerConn>) {
@@ -497,15 +726,16 @@ impl Consensus {
 
     // --- Handlers for inbound RPCs (called by the gRPC server) --------------
 
-    /// Handle an incoming AppendEntries from a leader. Apply the command if
-    /// the term is fresh enough; otherwise reject. Out-of-order seq returns
-    /// `success=false` so the leader can ship a snapshot.
+    /// Handle an incoming AppendEntries from a leader. Stores the command
+    /// in the pending buffer and applies it once the leader's commit index
+    /// covers this sequence.
     pub async fn handle_append_entries(
         &self,
         leader_id: String,
         term: u64,
         seq: u64,
         command: Vec<u8>,
+        commit_seq: u64,
     ) -> (bool, u64) {
         let (accepted, current_term) = self
             .update_and_persist(|mut st| {
@@ -531,36 +761,59 @@ impl Consensus {
             return (false, current_term);
         }
 
-        match state_command::decode(&command) {
-            Ok(cmd) => {
-                self.state_machine.apply(cmd).await;
-                self.note_applied().await;
-                (true, current_term)
-            }
-            Err(e) => {
-                warn!(error = ?e, "failed to decode AppendEntries payload");
-                (false, current_term)
-            }
+        if self
+            .with_command_log(|log| log.append(seq, &command))
+            .await
+            .is_err()
+        {
+            return (false, current_term);
         }
+        self.pending.write().await.insert(seq, command);
+        self.apply_committed(commit_seq).await;
+        (true, current_term)
     }
 
-    /// Handle an incoming heartbeat. Updates `last_heartbeat` and
-    /// learns about the current leader; never changes data.
-    pub async fn handle_heartbeat(&self, leader_id: String, term: u64) -> (bool, u64) {
-        self.update_and_persist(|mut st| {
-            if term < st.term {
-                return ((false, st.term), st);
-            }
-            if term > st.term {
-                st.term = term;
-                st.voted_for = None;
-            }
-            st.role = Role::Follower;
-            st.leader_id = Some(leader_id);
-            st.last_heartbeat = Instant::now();
-            ((true, st.term), st)
-        })
-        .await
+    /// Handle an incoming heartbeat. Updates `last_heartbeat`, learns about
+    /// the current leader, and applies any newly committed entries.
+    pub async fn handle_heartbeat(
+        &self,
+        leader_id: String,
+        term: u64,
+        commit_seq: u64,
+    ) -> (bool, u64) {
+        let (acknowledged, current_term) = self
+            .update_and_persist(|mut st| {
+                if term < st.term {
+                    return ((false, st.term), st);
+                }
+                if term > st.term {
+                    st.term = term;
+                    st.voted_for = None;
+                }
+                st.role = Role::Follower;
+                st.leader_id = Some(leader_id);
+                st.last_heartbeat = Instant::now();
+                ((true, st.term), st)
+            })
+            .await;
+
+        if acknowledged {
+            self.apply_committed(commit_seq).await;
+        }
+        (acknowledged, current_term)
+    }
+
+    /// Follower ack for a ReadIndex probe — confirms the requester is still
+    /// the leader we know.
+    pub async fn handle_read_index(&self, leader_id: String, term: u64) -> (bool, u64) {
+        let st = self.state.read().await;
+        if term < st.term {
+            return (false, st.term);
+        }
+        if st.leader_id.as_deref() == Some(leader_id.as_str()) && term == st.term {
+            return (true, st.term);
+        }
+        (false, st.term)
     }
 
     /// Handle a PreVote request. PreVote (Ongaro thesis §9.6) is a
@@ -670,9 +923,18 @@ impl Consensus {
             // rather than the leader's stale `last_seq` gap.
             let mut durable_snapshot = snapshot;
             durable_snapshot.last_seq = last_seq;
+            let _ = self
+                .with_command_log(|log| log.truncate_through(last_seq))
+                .await;
+            self.pending.write().await.clear();
             self.state_machine
                 .install_snapshot(durable_snapshot.clone())
                 .await;
+            {
+                let mut st = self.state.write().await;
+                st.commit_seq = last_seq;
+                st.last_applied = last_seq;
+            }
             self.applies_since_snapshot
                 .store(0, std::sync::atomic::Ordering::Relaxed);
             let this = self.clone();
@@ -726,9 +988,9 @@ impl Consensus {
     }
 
     async fn send_heartbeats(&self) {
-        let (term, last_seq) = {
+        let (term, commit_seq) = {
             let st = self.state.read().await;
-            (st.term, st.last_seq)
+            (st.term, st.commit_seq)
         };
         let peers: Vec<(String, Arc<PeerConn>)> = self
             .peers
@@ -740,7 +1002,6 @@ impl Consensus {
         for (id, peer) in peers {
             let leader_id = self.node_id.clone();
             let timeout = self.config.connection_timeout;
-            let last_seq_for_peer = last_seq;
             let this = self.clone();
             tokio::spawn(async move {
                 match peer.client(timeout).await {
@@ -748,6 +1009,7 @@ impl Consensus {
                         let req = HeartbeatRequest {
                             leader_id: leader_id.clone(),
                             term,
+                            commit_seq,
                         };
                         match client.heartbeat(req).await {
                             Ok(resp) => {
@@ -758,12 +1020,6 @@ impl Consensus {
                                 peer.reset().await;
                             }
                         }
-                        // Best-effort: also probe with an empty AppendEntries
-                        // so a follower that fell behind during a partition
-                        // can pick the next seq back up. If the follower's
-                        // seq is wrong, the leader will catch it via the
-                        // periodic snapshot push below.
-                        let _ = last_seq_for_peer;
                     }
                     Err(e) => debug!(peer = %id, error = ?e, "no client"),
                 }

--- a/rust/dref-raft/src/context.rs
+++ b/rust/dref-raft/src/context.rs
@@ -469,8 +469,9 @@ impl DRefContext for RaftDRefContext {
     }
 
     fn on_change_stream(&self, name: &str) -> BoxStream<'static, Result<ChangeEvent, DRefError>> {
-        // Subscribe to the LOCAL state machine. Followers apply commands
-        // too, so a subscriber on any node sees every committed change.
+        // Subscribe to the LOCAL state machine. Followers apply committed
+        // entries after the leader propagates the commit index, so a
+        // subscriber on any node eventually sees every committed change.
         let rx = self.inner.consensus.state_machine.subscribe();
         let want = name.to_string();
         let s = BroadcastStream::new(rx).filter_map(move |item| {

--- a/rust/dref-raft/src/grpc_server.rs
+++ b/rust/dref-raft/src/grpc_server.rs
@@ -20,8 +20,8 @@ use crate::proto::dref::{
 use crate::proto::dref_consensus::d_ref_consensus_server::DRefConsensus;
 use crate::proto::dref_consensus::{
     AppendEntriesRequest, AppendEntriesResponse, HeartbeatRequest, HeartbeatResponse,
-    InstallSnapshotRequest, InstallSnapshotResponse, PreVoteRequest, PreVoteResponse, VoteRequest,
-    VoteResponse,
+    InstallSnapshotRequest, InstallSnapshotResponse, PreVoteRequest, PreVoteResponse,
+    ReadIndexRequest, ReadIndexResponse, VoteRequest, VoteResponse,
 };
 use crate::state_command::StateCommand;
 use crate::state_machine::{unix_millis, ApplyResult};
@@ -50,6 +50,7 @@ impl DRefRaftService {
                 Status::failed_precondition(desc)
             }
             ConsensusError::NoLeader => Status::failed_precondition("no-leader:unknown"),
+            ConsensusError::QuorumLost => Status::unavailable("quorum-lost"),
             ConsensusError::Serialize(s) => Status::internal(format!("serialize: {s}")),
             ConsensusError::Transport(s) => Status::unavailable(s),
         }
@@ -87,11 +88,7 @@ impl DRefRaft for DRefRaftService {
         request: Request<GetElementRequest>,
     ) -> Result<Response<GetElementResponse>, Status> {
         let r = request.into_inner();
-        if !self.consensus.is_leader().await {
-            return Err(Self::map_err(ConsensusError::NotLeader {
-                leader_id: self.consensus.leader_id().await,
-            }));
-        }
+        self.consensus.read_index().await.map_err(Self::map_err)?;
         let value = self.consensus.state_machine.get(&r.name).await;
         Ok(Response::new(GetElementResponse { value }))
     }
@@ -154,7 +151,7 @@ impl DRefConsensus for DRefConsensusService {
         let r = request.into_inner();
         let (success, term) = self
             .consensus
-            .handle_append_entries(r.leader_id, r.term, r.seq, r.command)
+            .handle_append_entries(r.leader_id, r.term, r.seq, r.command, r.commit_seq)
             .await;
         Ok(Response::new(AppendEntriesResponse { success, term }))
     }
@@ -164,8 +161,23 @@ impl DRefConsensus for DRefConsensusService {
         request: Request<HeartbeatRequest>,
     ) -> Result<Response<HeartbeatResponse>, Status> {
         let r = request.into_inner();
-        let (acknowledged, term) = self.consensus.handle_heartbeat(r.leader_id, r.term).await;
+        let (acknowledged, term) = self
+            .consensus
+            .handle_heartbeat(r.leader_id, r.term, r.commit_seq)
+            .await;
         Ok(Response::new(HeartbeatResponse { acknowledged, term }))
+    }
+
+    async fn read_index(
+        &self,
+        request: Request<ReadIndexRequest>,
+    ) -> Result<Response<ReadIndexResponse>, Status> {
+        let r = request.into_inner();
+        let (granted, term) = self
+            .consensus
+            .handle_read_index(r.leader_id, r.term)
+            .await;
+        Ok(Response::new(ReadIndexResponse { granted, term }))
     }
 
     async fn request_vote(

--- a/rust/dref-raft/src/lib.rs
+++ b/rust/dref-raft/src/lib.rs
@@ -5,6 +5,7 @@
 //! (`proto/state_command.proto`) so Scala and Rust nodes can participate in
 //! the same cluster.
 
+pub mod command_log_store;
 pub mod config;
 pub mod consensus;
 pub mod context;
@@ -35,6 +36,9 @@ pub mod proto {
     }
 }
 
+pub use command_log_store::{
+    CommandLogEntry, CommandLogState, CommandLogStore, FileCommandLogStore, NoopCommandLogStore,
+};
 pub use config::{NodeEndpoint, RaftConfig};
 pub use context::RaftDRefContext;
 pub use ip_provider::{

--- a/rust/dref-raft/tests/consensus_compat_tests.rs
+++ b/rust/dref-raft/tests/consensus_compat_tests.rs
@@ -51,6 +51,7 @@ fn append_entries_carries_protobuf_state_command() {
         term: 7,
         command,
         seq: 99,
+        commit_seq: 42,
     };
     let encoded = req.encode_to_vec();
     let decoded = AppendEntriesRequest::decode(encoded.as_slice()).expect("decode");

--- a/rust/dref-raft/tests/consensus_persistence_tests.rs
+++ b/rust/dref-raft/tests/consensus_persistence_tests.rs
@@ -93,7 +93,7 @@ async fn with_storage_higher_term_via_append_entries_persists() {
     rm_dir(&dir);
     let engine = make_engine(Some(dir.clone())).await;
     engine
-        .handle_append_entries("leader-x".to_string(), 12, 0, vec![])
+        .handle_append_entries("leader-x".to_string(), 12, 0, vec![], 0)
         .await;
     let store = FileVoterStateStore::open(&dir).unwrap();
     let persisted = store.load().unwrap();
@@ -197,7 +197,7 @@ async fn pre_vote_refused_when_recent_leader_heartbeat() {
     // Step down from single-node leader so we're a follower observing an
     // external leader.
     engine.test_step_down_if_stale(1).await;
-    engine.handle_heartbeat("leader-x".to_string(), 1).await;
+    engine.handle_heartbeat("leader-x".to_string(), 1, 0).await;
 
     let (granted, term) = engine.handle_pre_vote("disruptor".to_string(), 50, 0).await;
     assert!(!granted, "must refuse pre-vote while a leader is fresh");

--- a/rust/dref-raft/tests/crosslang_command_log_tests.rs
+++ b/rust/dref-raft/tests/crosslang_command_log_tests.rs
@@ -1,0 +1,58 @@
+//! Golden command-log wire-format tests shared with Scala `CommandLogStoreSpec`.
+
+use dref_raft::command_log_store::{encode_for_test, CommandLogEntry, CommandLogState, CommandLogStore};
+use dref_raft::state_command::{self, StateCommand};
+use dref_raft::FileCommandLogStore;
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn read_golden_hex(name: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../compat/command_log_vectors.json");
+    let text = std::fs::read_to_string(path).expect("read command_log_vectors.json");
+    let needle = format!("\"name\": \"{name}\"");
+    let start = text.find(&needle).expect("vector name");
+    let tail = &text[start..];
+    let hex_key = tail.find("\"hex\": \"").expect("hex field") + 8;
+    let rest = &tail[hex_key..];
+    let end = rest.find('"').expect("hex end");
+    rest[..end].to_string()
+}
+
+#[test]
+fn single_set_element_record_matches_golden_bytes() {
+    let cmd = StateCommand::set_element("my-key", vec![1, 2, 3], Some(1_700_000_000));
+    let command = state_command::encode(&cmd).expect("encode");
+    let encoded = encode_for_test(
+        &CommandLogEntry {
+            seq: 1,
+            command,
+        },
+        0,
+    )
+    .expect("encode log");
+    assert_eq!(
+        hex(&encoded),
+        read_golden_hex("single_set_element_record")
+    );
+}
+
+#[test]
+fn file_store_round_trip() {
+    let dir = std::env::temp_dir().join(format!(
+        "dref-crosslang-cmdlog-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    let store = FileCommandLogStore::open(&dir).expect("open");
+    store.append(3, &[9, 9]).expect("append");
+    store.set_commit_seq(3).expect("commit");
+    let loaded = store.load().expect("load");
+    assert_eq!(loaded, CommandLogState {
+        commit_seq: 3,
+        entries: [(3, vec![9, 9])].into_iter().collect(),
+    });
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary
- Add real quorum commit for writes: the leader acks only after a majority stores the entry; unreachable quorums fail with `quorum-lost`.
- Add ReadIndex-style linearizable reads on the leader before serving `get`.
- Introduce a cross-language append-only command log (`command-log`, magic `DRFL`) fsync'd before replication acks, with restart recovery and snapshot truncation.

## Test plan
- [x] `sbt dref-raft/test` (60 tests)
- [x] `cd rust && cargo test -p dref-raft` (55 tests)
- [ ] Verify mixed Scala/Rust cluster still elects and replicates under the new proto fields


Made with [Cursor](https://cursor.com)