### PR TITLE
Fix command-log durability and concurrency bugs

### DIFF
--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/CommandLogStore.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/CommandLogStore.scala
@@ -27,6 +27,10 @@ trait CommandLogStore {
   def setCommitSeq(commitSeq: Long): Task[Unit]
   /** Drop every record with `seq <= throughSeq` and clamp the header commit index. */
   def truncateThrough(throughSeq: Long): Task[Unit]
+  /** Drop every record with `seq >= fromSeq`. Used to roll back a failed append; the header
+    * commit index is left alone (a failed append never advanced it).
+    */
+  def truncateFrom(fromSeq: Long): Task[Unit]
 }
 
 object CommandLogStore {
@@ -41,6 +45,7 @@ object CommandLogStore {
     def append(seq: Long, command: Array[Byte]): Task[Unit] = ZIO.unit
     def setCommitSeq(commitSeq: Long): Task[Unit] = ZIO.unit
     def truncateThrough(throughSeq: Long): Task[Unit] = ZIO.unit
+    def truncateFrom(fromSeq: Long): Task[Unit] = ZIO.unit
   }
 
   def file(dir: Path): Task[CommandLogStore] =
@@ -100,6 +105,20 @@ object CommandLogStore {
           val kept = loaded.entries.filter { case (seq, _) => seq > throughSeq }
           val newCommit = math.min(loaded.commitSeq, throughSeq)
           rewrite(newCommit, kept)
+        }
+      }
+
+    def truncateFrom(fromSeq: Long): Task[Unit] =
+      ZIO.attemptBlocking {
+        if !Files.exists(target) then ()
+        else {
+          val in = new DataInputStream(new FileInputStream(target.toFile))
+          val loaded =
+            try readLog(in)
+            catch case _: EOFException => throw new IOException(s"command-log file truncated: $target")
+            finally in.close()
+          val kept = loaded.entries.filter { case (seq, _) => seq < fromSeq }
+          rewrite(loaded.commitSeq, kept)
         }
       }
 

--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
@@ -55,6 +55,7 @@ final class ProtoConsensusEngine private (
   commandLogStore: CommandLogStore,
   persistMutex: Semaphore,
   logMutex: Semaphore,
+  applyMutex: Semaphore,
   snapshotStore: StateMachineSnapshotStore,
   snapshotMutex: Semaphore,
   appliesSinceSnapshot: Ref[Long]
@@ -136,8 +137,12 @@ final class ProtoConsensusEngine private (
       for {
         st       <- stateRef.get
         snapshot <- stateMachine.takeSnapshot
-        _        <- snapshotStore.save(snapshot.copy(lastSeq = st.lastSeq))
-        _        <- withCommandLog(_.truncateThrough(st.commitSeq))
+        // lastApplied — NOT lastSeq — is the highest seq actually reflected in the state
+        // machine. On a follower, lastSeq can race ahead of lastApplied via AppendEntries
+        // before the commit catches up; saving lastSeq would make the snapshot file lie
+        // about what's been applied and silently lose entries on restart.
+        _        <- snapshotStore.save(snapshot.copy(lastSeq = st.lastApplied))
+        _        <- withCommandLog(_.truncateThrough(st.lastApplied))
       } yield ()
     }
 
@@ -154,34 +159,58 @@ final class ProtoConsensusEngine private (
     */
   def currentTerm: UIO[Long] = stateRef.get.map(_.term)
 
-  /** Apply pending entries up to `commitSeq` and advance the committed/applied markers. */
+  /** Apply pending entries up to `commitSeq` and advance the committed/applied markers.
+    *
+    * Serialised on `applyMutex` so concurrent inbound RPCs (e.g. a heartbeat racing an
+    * AppendEntries with a larger commitSeq) cannot both pass the guard and double-apply the
+    * same pending entry.
+    *
+    * The effective commit index is capped to `lastSeq` — a leader may legitimately advertise
+    * a commitSeq past entries we haven't received yet, and we must not advance our on-disk
+    * commit past entries that aren't in our log. If a pending entry is still missing within
+    * the effective range (a concurrent AppendEntries bumped lastSeq but hasn't yet inserted
+    * the bytes), we stop at the last successfully applied seq; the next call retries.
+    */
   private def applyCommitted(commitSeq: Long): UIO[Unit] =
-    stateRef.get.flatMap { st =>
-      if commitSeq <= st.commitSeq then ZIO.unit
-      else
-        ZIO
-          .foldLeft((st.lastApplied + 1L) to commitSeq)(()) { (_, seq) =>
-            for {
-              pending <- pendingRef.get
-              _       <- pending.get(seq) match {
-                           case Some(value) =>
-                             for {
-                               cmd <- ZIO.attempt(StateCommand.parseFrom(value)).orDie
-                               _   <- stateMachine.apply(cmd)
-                               _   <- noteApplied
-                               _   <- stateRef.update(s => s.copy(lastApplied = seq))
-                               _   <- pendingRef.update(_ - seq)
-                             } yield ()
-                           case None =>
-                             ZIO.logWarning(s"missing pending entry for seq $seq")
-                         }
-            } yield ()
-          }
-          .flatMap(_ =>
-            stateRef.update(_.copy(commitSeq = commitSeq)) *>
-              withCommandLog(_.setCommitSeq(commitSeq))
-          )
+    applyMutex.withPermit {
+      stateRef.get.flatMap { st =>
+        val effective = math.min(commitSeq, st.lastSeq)
+        if effective <= st.commitSeq then ZIO.unit
+        else applyLoop(st.lastApplied + 1L, effective)
+      }
     }
+
+  private def applyLoop(start: Long, end: Long): UIO[Unit] = {
+    def advanceCommit(lastSuccess: Long): UIO[Unit] =
+      if lastSuccess >= start then
+        stateRef.update(_.copy(commitSeq = lastSuccess)) *>
+          withCommandLog(_.setCommitSeq(lastSuccess))
+      else ZIO.unit
+
+    def go(seq: Long, lastSuccess: Long): UIO[Unit] =
+      if seq > end then advanceCommit(lastSuccess)
+      else
+        pendingRef.get.flatMap { pending =>
+          pending.get(seq) match {
+            case Some(value) =>
+              for {
+                cmd <- ZIO.attempt(StateCommand.parseFrom(value)).orDie
+                _   <- stateMachine.apply(cmd)
+                _   <- stateRef.update(s => s.copy(lastApplied = seq))
+                _   <- pendingRef.update(_ - seq)
+                // noteApplied runs *after* lastApplied is updated so a forked snapshot
+                // reads a consistent (lastApplied, state-machine) pair.
+                _   <- noteApplied
+                _   <- go(seq + 1L, seq)
+              } yield ()
+            case None =>
+              ZIO.logWarning(s"pending entry for committed seq $seq not yet present; deferring") *>
+                advanceCommit(lastSuccess)
+          }
+        }
+
+    go(start, start - 1L)
+  }
 
   /** Push the current commit index to every follower so they apply pending entries. */
   private def propagateCommitSeq(commitSeq: Long, term: Long): UIO[Unit] =
@@ -216,7 +245,7 @@ final class ProtoConsensusEngine private (
       followerAcks                <- replicateForQuorum(term, seq, bytes, commitSeqBefore)
       totalAcks                    = 1 + followerAcks
       _                           <- ZIO.when(totalAcks < needed) {
-                                       withCommandLog(_.truncateThrough(seq - 1)) *>
+                                       withCommandLog(_.truncateFrom(seq)) *>
                                          stateRef.update(_.copy(lastSeq = seq - 1)) *>
                                          ZIO.fail(ConsensusError.QuorumLost)
                                      }
@@ -443,13 +472,15 @@ final class ProtoConsensusEngine private (
     for {
       st       <- stateRef.get
       snapshot <- stateMachine.takeSnapshot
+      // The snapshot reflects entries applied through lastApplied. Sending lastSeq would let
+      // the follower jump its commit index past entries the leader itself hasn't applied.
       _        <- client
                     .installSnapshot(
                       InstallSnapshotRequest(
                         leaderId = nodeId,
                         term = st.term,
                         snapshot = Some(snapshot),
-                        lastSeq = st.lastSeq
+                        lastSeq = st.lastApplied
                       )
                     )
                     .foldZIO(
@@ -599,7 +630,8 @@ final class ProtoConsensusEngine private (
                             leaderId = nodeId,
                             term = st.term,
                             snapshot = Some(snapshot),
-                            lastSeq = st.lastSeq
+                            // Snapshot covers entries applied through lastApplied — see sendSnapshotTo.
+                            lastSeq = st.lastApplied
                           )
                         )
                         .foldZIO(
@@ -669,11 +701,17 @@ object ProtoConsensusEngine {
       recoveredCommit = math.min(logState.commitSeq, maxLogSeq)
       initialCommitSeq = math.max(snapshotLastSeq, recoveredCommit)
       initialLastSeq   = math.max(snapshotLastSeq, maxLogSeq)
+      // A gap between the snapshot tip and the committed log range means we'd be
+      // booting a state machine with missing committed entries — silent divergence.
+      // Fail-fast so the operator sees the corruption and can restore from a peer.
       _              <- ZIO.foreachDiscard((snapshotLastSeq + 1L) to initialCommitSeq) { seq =>
                           logState.entries.get(seq) match {
                             case Some(bytes) =>
                               ZIO.attempt(StateCommand.parseFrom(bytes)).flatMap(stateMachine.apply).orDie
-                            case None        => ZIO.unit
+                            case None        =>
+                              ZIO.dieMessage(
+                                s"command log missing committed entry $seq (snapshotLastSeq=$snapshotLastSeq, commitSeq=$initialCommitSeq)"
+                              )
                           }
                         }
       initialPending  = logState.entries.filter { case (s, _) => s > initialCommitSeq }
@@ -709,6 +747,7 @@ object ProtoConsensusEngine {
                           .when(initialTerm != loaded.term || initialVotedFor != loaded.votedFor)
       persistMutex   <- Semaphore.make(1)
       logMutex       <- Semaphore.make(1)
+      applyMutex     <- Semaphore.make(1)
       snapshotMutex  <- Semaphore.make(1)
       appliesRef     <- Ref.make(0L)
       peersRef       <- Ref.make(peers)
@@ -723,6 +762,7 @@ object ProtoConsensusEngine {
       commandLogStore,
       persistMutex,
       logMutex,
+      applyMutex,
       snapshotStore,
       snapshotMutex,
       appliesRef

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/CommandLogStoreSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/CommandLogStoreSpec.scala
@@ -68,6 +68,25 @@ object CommandLogStoreSpec extends ZIOSpecDefault {
         state.entries.get(2L).exists(_.sameElements(Array[Byte](2)))
       )
     },
+    test("truncateFrom drops failed suffix and leaves commit untouched") {
+      for {
+        dir   <- tempDir
+        store <- CommandLogStore.file(dir)
+        _     <- store.append(1L, Array[Byte](1))
+        _     <- store.append(2L, Array[Byte](2))
+        _     <- store.append(3L, Array[Byte](3))
+        _     <- store.setCommitSeq(2L)
+        // Roll back the failed append at seq=3.
+        _     <- store.truncateFrom(3L)
+        state <- store.load
+      } yield assertTrue(
+        // commit index is untouched by a rollback.
+        state.commitSeq == 2L,
+        state.entries.get(1L).exists(_.sameElements(Array[Byte](1))),
+        state.entries.get(2L).exists(_.sameElements(Array[Byte](2))),
+        state.entries.get(3L).isEmpty
+      )
+    },
     test("on-disk bytes match cross-language golden vectors") {
       val cmd = StateCommands.setElement("my-key", Array[Byte](1, 2, 3), Some(1700000000L)).toByteArray
       val encoded = CommandLogStore.encodeForTest(CommandLogEntry(1L, cmd), commitSeq = 0L)

--- a/rust/dref-raft/src/command_log_store.rs
+++ b/rust/dref-raft/src/command_log_store.rs
@@ -51,7 +51,11 @@ pub trait CommandLogStore: Send + Sync {
     fn load(&self) -> Result<CommandLogState, CommandLogError>;
     fn append(&self, seq: u64, command: &[u8]) -> Result<(), CommandLogError>;
     fn set_commit_seq(&self, commit_seq: u64) -> Result<(), CommandLogError>;
+    /// Drop every record with `seq <= through_seq` and clamp the header commit index.
     fn truncate_through(&self, through_seq: u64) -> Result<(), CommandLogError>;
+    /// Drop every record with `seq >= from_seq`. Used to roll back a failed append; the
+    /// header commit index is left alone (a failed append never advanced it).
+    fn truncate_from(&self, from_seq: u64) -> Result<(), CommandLogError>;
 }
 
 pub struct NoopCommandLogStore;
@@ -70,6 +74,10 @@ impl CommandLogStore for NoopCommandLogStore {
     }
 
     fn truncate_through(&self, _through_seq: u64) -> Result<(), CommandLogError> {
+        Ok(())
+    }
+
+    fn truncate_from(&self, _from_seq: u64) -> Result<(), CommandLogError> {
         Ok(())
     }
 }
@@ -162,6 +170,23 @@ impl CommandLogStore for FileCommandLogStore {
             .collect();
         let new_commit = state.commit_seq.min(through_seq);
         self.rewrite(new_commit, &kept)
+    }
+
+    fn truncate_from(&self, from_seq: u64) -> Result<(), CommandLogError> {
+        let path = self.target();
+        if !path.exists() {
+            return Ok(());
+        }
+        let state = {
+            let mut file = File::open(&path)?;
+            read_log(&mut file)?
+        };
+        let kept: BTreeMap<u64, Vec<u8>> = state
+            .entries
+            .into_iter()
+            .filter(|(seq, _)| *seq < from_seq)
+            .collect();
+        self.rewrite(state.commit_seq, &kept)
     }
 }
 
@@ -301,6 +326,26 @@ mod tests {
         assert_eq!(loaded.commit_seq, 1);
         assert_eq!(loaded.entries.get(&1).map(|v| v.as_slice()), Some(&[1, 2, 3][..]));
         assert_eq!(loaded.entries.get(&2).map(|v| v.as_slice()), Some(&[4][..]));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn truncate_from_drops_failed_suffix_and_keeps_commit() {
+        let dir = temp_dir("truncate-from");
+        let _ = fs::remove_dir_all(&dir);
+        let store = FileCommandLogStore::open(&dir).unwrap();
+        store.append(1, &[1]).unwrap();
+        store.append(2, &[2]).unwrap();
+        store.append(3, &[3]).unwrap();
+        store.set_commit_seq(2).unwrap();
+        // Roll back the failed append at seq=3.
+        store.truncate_from(3).unwrap();
+        let loaded = store.load().unwrap();
+        // commit index is untouched by a rollback.
+        assert_eq!(loaded.commit_seq, 2);
+        assert!(loaded.entries.contains_key(&1));
+        assert!(loaded.entries.contains_key(&2));
+        assert!(!loaded.entries.contains_key(&3));
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/rust/dref-raft/src/consensus.rs
+++ b/rust/dref-raft/src/consensus.rs
@@ -140,6 +140,7 @@ pub struct Consensus {
     voter_store: StdArc<dyn VoterStateStore>,
     persist_mutex: Arc<Mutex<()>>,
     log_mutex: Arc<Mutex<()>>,
+    apply_mutex: Arc<Mutex<()>>,
     snapshot_store: StdArc<dyn StateMachineSnapshotStore>,
     snapshot_mutex: Arc<Mutex<()>>,
     applies_since_snapshot: Arc<std::sync::atomic::AtomicU64>,
@@ -185,12 +186,19 @@ impl Consensus {
         let recovered_commit = log_state.commit_seq.min(max_log_seq);
         let initial_commit_seq = snapshot_last_seq.max(recovered_commit);
         let initial_last_seq = snapshot_last_seq.max(max_log_seq);
+        // A gap between the snapshot tip and the committed log range means we'd be booting
+        // a state machine with missing committed entries — silent divergence. Fail-fast so
+        // the operator sees the corruption and can restore from a peer.
         for seq in (snapshot_last_seq + 1)..=initial_commit_seq {
-            if let Some(bytes) = log_state.entries.get(&seq) {
-                if let Ok(cmd) = state_command::decode(bytes) {
-                    state_machine.apply(cmd).await;
-                }
-            }
+            let bytes = log_state.entries.get(&seq).unwrap_or_else(|| {
+                panic!(
+                    "command log missing committed entry {seq} \
+                     (snapshot_last_seq={snapshot_last_seq}, commit_seq={initial_commit_seq})"
+                )
+            });
+            let cmd = state_command::decode(bytes)
+                .unwrap_or_else(|e| panic!("failed to decode committed entry {seq}: {e}"));
+            state_machine.apply(cmd).await;
         }
         let initial_pending: BTreeMap<u64, Vec<u8>> = log_state
             .entries
@@ -255,6 +263,7 @@ impl Consensus {
             voter_store,
             persist_mutex: Arc::new(Mutex::new(())),
             log_mutex: Arc::new(Mutex::new(())),
+            apply_mutex: Arc::new(Mutex::new(())),
             snapshot_store,
             snapshot_mutex: Arc::new(Mutex::new(())),
             applies_since_snapshot: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -326,14 +335,27 @@ impl Consensus {
             return;
         }
         let threshold = self.config.snapshot_every as u64;
-        let next = self
-            .applies_since_snapshot
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            + 1;
-        if next >= threshold {
-            // Reset by subtracting `next` so concurrent increments are accounted for.
-            self.applies_since_snapshot
-                .fetch_sub(next, std::sync::atomic::Ordering::Relaxed);
+        // CAS loop equivalent to Scala's Ref.modify: read the counter, decide whether to
+        // reset (if we've hit threshold) or bump (otherwise), and retry on contention. A
+        // naive fetch_add + fetch_sub can underflow a u64 under concurrent triggers.
+        use std::sync::atomic::Ordering::Relaxed;
+        let triggered = loop {
+            let prev = self.applies_since_snapshot.load(Relaxed);
+            let next = prev + 1;
+            let (new_val, triggered) = if next >= threshold {
+                (0, true)
+            } else {
+                (next, false)
+            };
+            if self
+                .applies_since_snapshot
+                .compare_exchange_weak(prev, new_val, Relaxed, Relaxed)
+                .is_ok()
+            {
+                break triggered;
+            }
+        };
+        if triggered {
             let this = self.clone();
             tokio::spawn(async move {
                 if let Err(e) = this.persist_snapshot_now().await {
@@ -347,15 +369,18 @@ impl Consensus {
     /// triggers don't both write — the second waits, then takes a fresh snapshot itself.
     async fn persist_snapshot_now(&self) -> Result<(), String> {
         let _guard = self.snapshot_mutex.lock().await;
-        let commit_seq = self.state.read().await.commit_seq;
-        let last_seq = self.state.read().await.last_seq;
+        // last_applied — NOT last_seq — is the highest seq actually reflected in the state
+        // machine. On a follower, last_seq can race ahead of last_applied via AppendEntries
+        // before the commit catches up; saving last_seq would make the snapshot file lie
+        // about what's been applied and silently lose entries on restart.
+        let last_applied = self.state.read().await.last_applied;
         let mut snapshot = self.state_machine.take_snapshot().await;
-        snapshot.last_seq = last_seq;
+        snapshot.last_seq = last_applied;
         self.snapshot_store
             .save(&snapshot)
             .map_err(|e| e.to_string())?;
         self.with_command_log(|log| {
-            log.truncate_through(commit_seq)
+            log.truncate_through(last_applied)
                 .map_err(|e| e.to_string())
         })
         .await
@@ -426,48 +451,74 @@ impl Consensus {
         cluster_size / 2 + 1
     }
 
+    /// Apply pending entries up to `commit_seq` and advance the committed/applied markers.
+    ///
+    /// Serialised on `apply_mutex` so concurrent inbound RPCs (e.g. a heartbeat racing an
+    /// AppendEntries with a larger `commit_seq`) cannot both pass the guard and double-apply
+    /// the same pending entry.
+    ///
+    /// The effective commit index is capped to `last_seq` — a leader may legitimately
+    /// advertise a `commit_seq` past entries we haven't received yet, and we must not
+    /// advance our on-disk commit past entries that aren't in our log. If a pending entry
+    /// is still missing within the effective range (a concurrent AppendEntries bumped
+    /// `last_seq` but hasn't yet inserted the bytes), we stop at the last successfully
+    /// applied seq; the next call retries.
     async fn apply_committed(&self, commit_seq: u64) {
-        let start = {
+        let _guard = self.apply_mutex.lock().await;
+        let (start, effective, current_commit) = {
             let st = self.state.read().await;
-            if commit_seq <= st.commit_seq {
+            let effective = commit_seq.min(st.last_seq);
+            if effective <= st.commit_seq {
                 return;
             }
-            st.last_applied + 1
+            (st.last_applied + 1, effective, st.commit_seq)
         };
-        for seq in start..=commit_seq {
+        let mut last_success: Option<u64> = None;
+        for seq in start..=effective {
             let bytes = {
                 let pending = self.pending.read().await;
                 pending.get(&seq).cloned()
             };
             let Some(bytes) = bytes else {
-                warn!(seq, commit_seq, "missing pending entry while applying commit");
-                return;
+                warn!(
+                    seq,
+                    commit_seq = effective,
+                    "pending entry for committed seq not yet present; deferring"
+                );
+                break;
             };
             match state_command::decode(&bytes) {
                 Ok(cmd) => {
                     self.state_machine.apply(cmd).await;
-                    self.note_applied().await;
                     {
                         let mut st = self.state.write().await;
                         st.last_applied = seq;
                     }
                     self.pending.write().await.remove(&seq);
+                    // note_applied runs *after* last_applied is updated so a forked snapshot
+                    // reads a consistent (last_applied, state-machine) pair.
+                    self.note_applied().await;
+                    last_success = Some(seq);
                 }
                 Err(e) => {
-                    warn!(error = ?e, seq, "failed to decode pending entry");
-                    return;
+                    warn!(error = ?e, seq, "failed to decode pending entry; deferring");
+                    break;
                 }
             }
         }
-        {
-            let mut st = self.state.write().await;
-            if commit_seq > st.commit_seq {
-                st.commit_seq = commit_seq;
+        if let Some(lastest) = last_success {
+            if lastest > current_commit {
+                {
+                    let mut st = self.state.write().await;
+                    if lastest > st.commit_seq {
+                        st.commit_seq = lastest;
+                    }
+                }
+                let _ = self
+                    .with_command_log(|log| log.set_commit_seq(lastest))
+                    .await;
             }
         }
-        let _ = self
-            .with_command_log(|log| log.set_commit_seq(commit_seq))
-            .await;
     }
 
     async fn propagate_commit_seq(&self, commit_seq: u64, term: u64) {
@@ -546,7 +597,7 @@ impl Consensus {
         let total_acks = 1 + follower_acks;
         if total_acks < needed {
             let _ = self
-                .with_command_log(|log| log.truncate_through(seq - 1))
+                .with_command_log(|log| log.truncate_from(seq))
                 .await;
             let mut st = self.state.write().await;
             st.last_seq = seq - 1;
@@ -694,9 +745,11 @@ impl Consensus {
     }
 
     async fn send_snapshot_to(&self, peer_id: &str, peer: &Arc<PeerConn>) {
-        let (term, last_seq, still_leader) = {
+        // last_applied — NOT last_seq — bounds the snapshot. Sending last_seq would let the
+        // follower advance its commit index past entries the leader itself hasn't applied.
+        let (term, last_applied, still_leader) = {
             let st = self.state.read().await;
-            (st.term, st.last_seq, st.role == Role::Leader)
+            (st.term, st.last_applied, st.role == Role::Leader)
         };
         if !still_leader {
             return;
@@ -708,7 +761,7 @@ impl Consensus {
                     leader_id: self.node_id.clone(),
                     term,
                     snapshot: Some(snapshot),
-                    last_seq,
+                    last_seq: last_applied,
                 };
                 match client.install_snapshot(req).await {
                     Ok(resp) => {
@@ -1188,9 +1241,10 @@ impl Consensus {
     /// Send the current state machine snapshot to every peer. Called when
     /// we just won an election or when a follower asks to be caught up.
     async fn broadcast_snapshot(&self) {
-        let (term, last_seq) = {
+        // Snapshot covers entries applied through last_applied — see send_snapshot_to.
+        let (term, last_applied) = {
             let st = self.state.read().await;
-            (st.term, st.last_seq)
+            (st.term, st.last_applied)
         };
         let snapshot = self.state_machine.take_snapshot().await;
         let peers: Vec<(String, Arc<PeerConn>)> = self
@@ -1212,7 +1266,7 @@ impl Consensus {
                             leader_id,
                             term,
                             snapshot: Some(snapshot),
-                            last_seq,
+                            last_seq: last_applied,
                         };
                         match client.install_snapshot(req).await {
                             Ok(resp) => {


### PR DESCRIPTION
## Summary

Seven bugs in the new `CommandLogStore` integration were found during code review and fixed in this branch. Targets `cursor/command-log-store-scala` so the diff is just the fix commit.

## Bugs fixed

1. **QuorumLost rollback didn't actually drop the failed entry.** `submit()` called `truncateThrough(seq - 1)`, but `truncateThrough` drops `<= throughSeq` — the just-appended entry stayed on disk and would be replayed on restart. Added `truncateFrom(fromSeq)` (drops `>= fromSeq`, leaves the commit header alone) and switched the rollback to use it.

2. **Snapshot `lastSeq` lied about applied state.** `persistSnapshotNow` was writing `snapshot.lastSeq = state.lastSeq`, but on a follower `lastSeq` can race ahead of `lastApplied`. A snapshot fork mid-apply would persist a file claiming to cover entries that were never applied to the state machine. Changed to `lastApplied` for the on-disk snapshot and for outbound `InstallSnapshot` RPCs (`sendSnapshotTo` / `broadcastSnapshot`).

3. **Rust `applies_since_snapshot` underflow.** `fetch_add` followed by `fetch_sub(next)` could wrap a `u64` under concurrent triggers. Replaced with a `compare_exchange_weak` loop matching Scala's atomic-modify semantics.

4. **Concurrent `apply_committed` could double-apply.** A heartbeat racing an AppendEntries could both pass the `lastApplied` guard and apply the same pending entry twice. Added an `apply_mutex` (Scala `Semaphore` / Rust `tokio::Mutex`) that serialises the apply loop.

5. **Commit could advance past `lastSeq`.** A leader's heartbeat can carry a `commitSeq` past entries we haven't received yet. The effective commit is now capped to `lastSeq`, and on a still-missing pending entry the loop stops at the last applied seq instead of warning-and-continuing (which previously advanced commit past unapplied entries).

6. **Silent gap on initial replay.** The constructor's replay loop skipped missing entries between `snapshotLastSeq` and `initialCommitSeq` with `ZIO.unit` / silent discard. Made this fatal — a missing committed entry indicates corruption and crashing is better than silently diverging.

7. **`noteApplied` ordering.** The forked snapshot now reads state *after* `lastApplied` is updated, so it sees a consistent `(lastApplied, state-machine)` pair.

## Why

These are durability and consistency bugs in the Raft log path. Most are silent on the golden path but bite under crashes, restarts, and concurrent RPCs — exactly the scenarios the new `CommandLogStore` exists to handle.

## Test plan

- [x] `cargo test` — all 56 Rust tests pass
- [x] `sbt dref-raft/test` — all 60 Scala tests pass
- [x] Added a `truncateFrom` regression test in both languages
- [ ] Reviewer to spot-check the `apply_committed` cap + defer logic against the Raft invariants
- [ ] Reviewer to confirm the `snapshot.lastSeq = lastApplied` change doesn't break any callers that assumed `lastSeq` semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)