### PR TITLE
Fix Raft replication livelock on leader failover with uncommitted tail

### DIFF
--- a/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
+++ b/dref-raft/src/main/scala/io/github/tobia80/dref/raft/proto/ProtoConsensusEngine.scala
@@ -597,17 +597,44 @@ final class ProtoConsensusEngine private (
                                           stateRef
                                             .modify { st =>
                                               if st.role == Role.Candidate && st.term == term then
-                                                val next = st.copy(role = Role.Leader, leaderId = Some(nodeId))
-                                                (true, next)
+                                                (true, st.copy(role = Role.Leader, leaderId = Some(nodeId)))
                                               else (false, st)
                                             }
                                             .flatMap { elected =>
-                                              ZIO.logInfo(s"node $nodeId elected leader term $term").when(elected) *>
-                                                broadcastSnapshot.when(elected)
+                                              ZIO
+                                                .when(elected) {
+                                                  ZIO.logInfo(s"node $nodeId elected leader term $term") *>
+                                                    discardUncommittedTail *>
+                                                    broadcastSnapshot
+                                                }
+                                                .unit
                                             }
                                         else ZIO.logInfo(s"node $nodeId lost election term $term votes $votes")
                                     }
     } yield ()
+
+  /** Drop the uncommitted tail of the log when stepping up to leader.
+    *
+    * A node can win an election while it still holds entries the previous leader replicated but never committed
+    * (`seq > lastApplied`, sitting in `pending`). The new leader brings followers in sync by shipping a snapshot taken
+    * at `lastApplied`, which resets each follower's `lastSeq` to the committed tip. If we kept our inflated `lastSeq`,
+    * the next write would be assigned a seq past what followers expect, every AppendEntries would be rejected for the
+    * gap, and replication would livelock. Those entries were never acked to a client, so dropping them is safe; new
+    * writes resume from the committed tip.
+    */
+  private[raft] def discardUncommittedTail: UIO[Unit] =
+    for {
+      discardFrom <- stateRef.modify(st => (st.lastApplied + 1L, st.copy(lastSeq = st.lastApplied)))
+      _           <- pendingRef.update(_.filter { case (seq, _) => seq < discardFrom })
+      _           <- withCommandLog(_.truncateFrom(discardFrom))
+    } yield ()
+
+  /** Test-only read of `(lastSeq, lastApplied, pendingSize)` for asserting log-reconciliation invariants. */
+  private[raft] def stateForTest: UIO[(Long, Long, Int)] =
+    for {
+      st      <- stateRef.get
+      pending <- pendingRef.get
+    } yield (st.lastSeq, st.lastApplied, pending.size)
 
   private def broadcastSnapshot: UIO[Unit] =
     for {

--- a/dref-raft/src/test/scala/io/github/tobia80/dref/raft/ProtoConsensusPersistenceSpec.scala
+++ b/dref-raft/src/test/scala/io/github/tobia80/dref/raft/ProtoConsensusPersistenceSpec.scala
@@ -316,6 +316,38 @@ object ProtoConsensusPersistenceSpec extends ZIOSpecDefault {
         verifier     <- StateMachineSnapshotStore.file(dir)
         loaded       <- verifier.load
       } yield assertTrue(loaded.isEmpty)
+    },
+    test("promotion discards the uncommitted tail so lastSeq matches the committed tip") {
+      // Regression: a node elected leader while holding an uncommitted tail
+      // (lastSeq > lastApplied) must drop it so its next assigned seq lines up
+      // with what followers — reset to lastApplied by the post-election
+      // snapshot — expect. Otherwise every AppendEntries is rejected for a
+      // permanent gap and replication livelocks.
+      for {
+        engine <- makeEngine(None)
+        // Accept entries 1 and 2 from a remote leader; only entry 1 is
+        // committed (commitSeq advances to 1), leaving entry 2 uncommitted.
+        _      <- engine.handleAppendEntries(leaderId = "L", term = 2L, seq = 1L, command = setElement("a", Array[Byte](1)).toByteArray, commitSeq = 0L)
+        _      <- engine.handleAppendEntries(leaderId = "L", term = 2L, seq = 2L, command = setElement("b", Array[Byte](2)).toByteArray, commitSeq = 1L)
+        before <- engine.stateForTest
+        _      <- engine.discardUncommittedTail
+        after  <- engine.stateForTest
+      } yield assertTrue(
+        before._1 == 2L,          // lastSeq advanced past the committed tip
+        before._2 == 1L,          // lastApplied is the committed tip
+        before._3 == 1,           // entry 2 still pending
+        after._1 == 1L,           // lastSeq reset to the committed tip
+        after._2 == 1L,           // lastApplied untouched
+        after._3 == 0             // uncommitted pending cleared
+      )
+    },
+    test("promotion leaves a fully-committed log untouched") {
+      for {
+        engine <- makeEngine(None)
+        _      <- engine.handleAppendEntries(leaderId = "L", term = 2L, seq = 1L, command = setElement("a", Array[Byte](1)).toByteArray, commitSeq = 1L)
+        _      <- engine.discardUncommittedTail
+        after  <- engine.stateForTest
+      } yield assertTrue(after._1 == 1L, after._2 == 1L, after._3 == 0)
     }
   ) @@ TestAspect.withLiveClock @@ TestAspect.sequential
 }

--- a/rust/dref-raft/src/consensus.rs
+++ b/rust/dref-raft/src/consensus.rs
@@ -1212,6 +1212,7 @@ impl Consensus {
                 st.leader_id = Some(self.node_id.clone());
                 info!(node = %self.node_id, term, "elected leader");
                 drop(st);
+                self.discard_uncommitted_tail().await;
                 // New leader ships a snapshot to bring followers in sync.
                 self.broadcast_snapshot().await;
             }
@@ -1220,6 +1221,30 @@ impl Consensus {
             // Stay candidate; next tick may try again, or a higher-term
             // leader will demote us via heartbeat.
         }
+    }
+
+    /// Drop the uncommitted tail of the log when stepping up to leader.
+    ///
+    /// A node can win an election while it still holds entries the previous
+    /// leader replicated but never committed (`seq > last_applied`, sitting in
+    /// `pending`). The new leader brings followers in sync by shipping a
+    /// snapshot taken at `last_applied`, which resets each follower's
+    /// `last_seq` to the committed tip. If we kept our inflated `last_seq`, the
+    /// next write would be assigned a seq past what followers expect, every
+    /// AppendEntries would be rejected for the gap, and replication would
+    /// livelock. Those entries were never acked to a client, so dropping them
+    /// is safe; new writes resume from the committed tip.
+    async fn discard_uncommitted_tail(&self) {
+        let discard_from = {
+            let mut st = self.state.write().await;
+            let discard_from = st.last_applied + 1;
+            st.last_seq = st.last_applied;
+            discard_from
+        };
+        self.pending.write().await.retain(|seq, _| *seq < discard_from);
+        let _ = self
+            .with_command_log(|log| log.truncate_from(discard_from))
+            .await;
     }
 
     /// Send the current state machine snapshot to every peer. Called when
@@ -1253,5 +1278,72 @@ pub async fn wait_for_leader(c: &Consensus, max: Duration) -> Option<String> {
             return None;
         }
         sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_machine::StateMachine;
+
+    async fn test_consensus() -> Consensus {
+        // No peers + no persisted state: the node boots as a single-node
+        // leader, which is irrelevant here — we drive the state directly.
+        Consensus::new(
+            "node-test".to_string(),
+            StateMachine::new(),
+            RaftConfig::default(),
+        )
+        .await
+    }
+
+    /// Regression: a node elected leader while holding an uncommitted tail
+    /// (`last_seq > last_applied`) must drop that tail so its next assigned
+    /// seq lines up with what followers — reset to `last_applied` by the
+    /// post-election snapshot — expect. Otherwise every AppendEntries is
+    /// rejected for a permanent gap and replication livelocks.
+    #[tokio::test]
+    async fn discard_uncommitted_tail_resets_last_seq_and_clears_pending() {
+        let c = test_consensus().await;
+        // Accepted entries 1..=5 from a prior leader; only 1..=2 committed.
+        {
+            let mut st = c.state.write().await;
+            st.last_applied = 2;
+            st.commit_seq = 2;
+            st.last_seq = 5;
+        }
+        {
+            let mut pending = c.pending.write().await;
+            pending.insert(3, vec![3]);
+            pending.insert(4, vec![4]);
+            pending.insert(5, vec![5]);
+        }
+
+        c.discard_uncommitted_tail().await;
+
+        let st = c.state.read().await;
+        assert_eq!(st.last_seq, 2, "last_seq must drop to the committed tip");
+        assert_eq!(st.last_applied, 2);
+        assert!(
+            c.pending.read().await.is_empty(),
+            "uncommitted pending entries must be cleared on promotion"
+        );
+    }
+
+    /// A fully-committed log has no uncommitted tail, so promotion leaves
+    /// `last_seq` untouched.
+    #[tokio::test]
+    async fn discard_uncommitted_tail_is_noop_when_fully_committed() {
+        let c = test_consensus().await;
+        {
+            let mut st = c.state.write().await;
+            st.last_applied = 4;
+            st.commit_seq = 4;
+            st.last_seq = 4;
+        }
+
+        c.discard_uncommitted_tail().await;
+
+        assert_eq!(c.state.read().await.last_seq, 4);
     }
 }


### PR DESCRIPTION
A node can win an election while it still holds entries the previous
leader replicated but never committed (seq > lastApplied, sitting in the
pending buffer). The new leader catches followers up by shipping a
snapshot taken at lastApplied, which resets each follower's lastSeq to
the committed tip. The leader, however, kept its inflated lastSeq, so the
next client write was assigned a seq past what followers expected. Every
AppendEntries was then rejected for the gap, the leader replied with
another snapshot that reset followers again, and replication livelocked —
no write could ever reach quorum after the failover.

Both the Rust and Scala engines now discard the uncommitted tail on
promotion: lastSeq is reset to lastApplied, pending entries above the
committed tip are dropped, and the command log is truncated to match.
Those entries were never acked to a client, so dropping them is safe and
new writes resume cleanly from the committed tip.

Adds regression tests in both languages covering the uncommitted-tail
reset and the fully-committed no-op case.

https://claude.ai/code/session_01GuvRtvKwtcQBEdyL3vzbFb